### PR TITLE
Add command to get the binary version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "protofetch"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -43,4 +43,6 @@ pub enum Command {
         #[clap(short, long)]
         name: Option<String>,
     },
+    /// Get current version of protofetch
+    Version,
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 
 /// Dependency management tool for Protocol Buffers files.
 #[derive(Debug, Parser)]
-#[clap(version = "0.0.1")]
+#[clap(version)]
 pub struct CliArgs {
     #[clap(subcommand)]
     pub cmd: Command,
@@ -47,6 +47,4 @@ pub enum Command {
         #[clap(short, long)]
         name: Option<String>,
     },
-    /// Get current version of protofetch
-    Version,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,9 @@ use protofetch::{
     cli::{args::CliArgs, command_handlers},
 };
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -43,6 +46,10 @@ fn run() -> Result<(), Box<dyn Error>> {
         }
         cli::args::Command::Migrate { directory, name } => {
             command_handlers::do_migrate(&directory, name.as_deref(), &cli_args.module_location)
+        }
+        cli::args::Command::Version => {
+            println!("{VERSION}");
+            Ok(())
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,6 @@ use protofetch::{
     cli::{args::CliArgs, command_handlers},
 };
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -56,10 +53,6 @@ fn run() -> Result<(), Box<dyn Error>> {
         }
         cli::args::Command::Migrate { directory, name } => {
             command_handlers::do_migrate(&directory, name.as_deref(), &cli_args.module_location)
-        }
-        cli::args::Command::Version => {
-            println!("{VERSION}");
-            Ok(())
         }
     }
 }


### PR DESCRIPTION
I have found nothing nice for getting it from git tags, so ended up using the one from cargo.

This is mainly useful for `sbt-protodep` version checking of binaries.