### PR TITLE
Fix binary name to match location in the archive

### DIFF
--- a/.github/npm/getBinary.js
+++ b/.github/npm/getBinary.js
@@ -28,7 +28,7 @@ function getBinary() {
 	const platform = getPlatform();
 	const version = require('../package.json').version;
 	const url = `https://github.com/coralogix/protofetch/releases/download/v${ version }/protofetch_${ platform }.tar.gz`;
-	const name = 'release/protofetch';
+	const name = 'protofetch';
 
 	new Binary(name, url);
 }

--- a/.github/npm/getBinary.js
+++ b/.github/npm/getBinary.js
@@ -26,7 +26,7 @@ function getPlatform() {
 
 function getBinary() {
 	const platform = getPlatform();
-	const version = require('../package.json').version;
+	const version = require('./package.json').version;
 	const url = `https://github.com/coralogix/protofetch/releases/download/v${ version }/protofetch_${ platform }.tar.gz`;
 	const name = 'protofetch';
 

--- a/.github/npm/getBinary.js
+++ b/.github/npm/getBinary.js
@@ -28,8 +28,9 @@ function getBinary() {
 	const platform = getPlatform();
 	const version = require('../package.json').version;
 	const url = `https://github.com/coralogix/protofetch/releases/download/v${ version }/protofetch_${ platform }.tar.gz`;
-	const name = 'cx-protofetch';
-	return new Binary(name, url, );
+	const name = 'release/protofetch';
+
+	new Binary(name, url);
 }
 
 module.exports = getBinary;

--- a/.github/npm/package.json
+++ b/.github/npm/package.json
@@ -1,15 +1,15 @@
 {
   "name": "cx-protofetch",
-  "version": "VERSION#TO#REPLACE",
+  "version": "v0.0.13",
   "description": "A source dependency management tool for Protobuf.",
   "repository": "https://github.com/coralogix/protofetch.git",
   "homepage": "https://github.com/coralogix/protofetch",
   "license": "Apache-2.0",
   "bin": {
-    "protofetch": "npm/run.js"
+    "protofetch": "run.js"
   },
   "scripts": {
-    "postinstall": "node npm/scripts.js install"
+    "postinstall": "node scripts.js install"
   },
   "dependencies": {
     "binary-install": "^1.0.1"

--- a/.github/npm/package.json
+++ b/.github/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cx-protofetch",
-  "version": "v0.0.13",
+  "version": "VERSION#TO#REPLACE",
   "description": "A source dependency management tool for Protobuf.",
   "repository": "https://github.com/coralogix/protofetch.git",
   "homepage": "https://github.com/coralogix/protofetch",
@@ -26,9 +26,6 @@
     "dependencies",
     "dependency-manager",
     "grpc"
-  ],
-  "files": [
-    "npm/**/*"
   ],
   "main": "index.js"
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Publish npm package
         run: |
           export VERSION=$(sed -n -e '/version/ s/.* = *//p' "Cargo.toml" | head -1 | tr -d '"')
-          # Tee had issue to write to the same file which is used for read soe creating a temp
+          # Tee had issue to write to the same file which is used for read so creating a temp package,json file
           mv .github/package.json .github/package.json.temp 
           sed -i "s/VERSION#TO#REPLACE/v${VERSION}/g" .github/package.json.temp |  tee .github/package.json
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ".npmrc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build for release linux
         run: |
           cargo build --release
-          tar -czvf protofetch_linux_amd64.tar.gz target/release/protofetch
+          tar -C target/release/ -czvf protofetch_linux_amd64.tar.gz protofetch
 
       - name: Upload release
         uses: softprops/action-gh-release@v1
@@ -78,7 +78,7 @@ jobs:
         # We would need self-hosted arm runner for the correct target - for now we use `vendored-openssl` feature on `git2-rs dependency to overcome it
         run: |
           cargo build --release # --target=aarch64-apple-darwin
-          tar -czvf protofetch_darwin_arm64.tar.gz target/release/protofetch
+          tar -C target/release/ -czvf protofetch_darwin_arm64.tar.gz protofetch
 
       - name: Upload release
         uses: softprops/action-gh-release@v1
@@ -112,7 +112,7 @@ jobs:
       - name: Build for release mac-amd64
         run: |
           cargo build --release
-          tar -czvf protofetch_darwin_amd64.tar.gz target/release/protofetch
+          tar -C target/release/ -czvf protofetch_darwin_amd64.tar.gz protofetch
 
       - name: Upload release
         uses: softprops/action-gh-release@v1
@@ -146,7 +146,7 @@ jobs:
       - name: Build for release win64
         run: |
           cargo build --release
-          tar -czvf protofetch_win64.tar.gz target/release/protofetch.exe
+          tar -C target/release/ -czvf protofetch_win64.tar.gz protofetch.exe
 
       - name: Upload release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,9 @@ jobs:
       - name: Publish npm package
         run: |
           export VERSION=$(sed -n -e '/version/ s/.* = *//p' "Cargo.toml" | head -1 | tr -d '"')
-          sed -i "s/VERSION#TO#REPLACE/v${VERSION}/g" .github/package.json |  tee .github/package.json
+          # Tee had issue to write to the same file which is used for read soe creating a temp
+          mv .github/package.json .github/package.json.temp 
+          sed -i "s/VERSION#TO#REPLACE/v${VERSION}/g" .github/package.json.temp |  tee .github/package.json
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ".npmrc"
           npm publish .github
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,10 +165,10 @@ jobs:
         run: |
           export VERSION=$(sed -n -e '/version/ s/.* = *//p' "Cargo.toml" | head -1 | tr -d '"')
           # Tee had issue to write to the same file which is used for read so creating a temp package,json file
-          mv .github/package.json .github/package.json.temp 
-          sed -i "s/VERSION#TO#REPLACE/v${VERSION}/g" .github/package.json.temp |  tee .github/package.json
+          mv .github/npm/package.json .github/npm/package.json.temp 
+          sed -i "s/VERSION#TO#REPLACE/v${VERSION}/g" .github/npm/package.json.temp |  tee .github/npm/package.json
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ".npmrc"
-          npm publish .github
+          npm publish .github/npm
 
   crates-io:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Publish npm package
         run: |
           export VERSION=$(sed -n -e '/version/ s/.* = *//p' "Cargo.toml" | head -1 | tr -d '"')
-          # Tee had issue to write to the same file which is used for read so creating a temp package,json file
+          # Tee had issue to write to the same file which is used for read so creating a temp package.json file
           mv .github/npm/package.json .github/npm/package.json.temp 
           sed -i "s/VERSION#TO#REPLACE/v${VERSION}/g" .github/npm/package.json.temp |  tee .github/npm/package.json
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ".npmrc"


### PR DESCRIPTION
There're several issues that this PR is fixing:
* publish to the npm registry - tee doesn't seem to work properly when it's writing to the same file that is being read - so in the CI, temporary file was created for this purpose
* npm and I guess other tools too expect the binary to be located in the root tar.gz after unwrap, this was fixed by adding current directory in the packaging step instead of publishing all the file hierarchy including `target/release` directories.