### PR TITLE
Remove redundant v from the package json version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
           export VERSION=$(sed -n -e '/version/ s/.* = *//p' "Cargo.toml" | head -1 | tr -d '"')
           # Tee had issue to write to the same file which is used for read so creating a temp package.json file
           mv .github/npm/package.json .github/npm/package.json.temp 
-          sed "s/VERSION#TO#REPLACE/v${VERSION}/g" .github/npm/package.json.temp |  tee .github/npm/package.json
+          sed "s/VERSION#TO#REPLACE/${VERSION}/g" .github/npm/package.json.temp |  tee .github/npm/package.json
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ".npmrc"
           npm publish .github/npm
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.0.18"
+version = "0.0.19"
 edition = "2018"
 license = "Apache-2.0"
 description = "A source dependency management tool for Protobuf."


### PR DESCRIPTION
For some reason it worked like that for the `npm` v6 but for 7 and 8 it's causing issues.

The `package.json` file should not contain `v` prefix - you can see it's there now:
https://www.npmjs.com/package/cx-protofetch/v/0.0.18?activeTab=explore

In the `npm` v6, it was automatically omitted for some reason but it didn't work in later `npm` versions.