### PR TITLE
Fix Linux binary to work with various Linux distros

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
 
       - name: Build for release linux
         run: |
-          cargo build --release
+          rustup target add x86_64-unknown-linux-musl
+          apt-get install musl-tools
+          cargo build --release --target=x86_64-unknown-linux-musl
           mv target/release bin/
           tar -czvf protofetch_linux_amd64.tar.gz bin/protofetch
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           rustup target add x86_64-unknown-linux-musl
           apt-get install musl-tools
           cargo build --release --target=x86_64-unknown-linux-musl
-          mv target/release bin/
+          mv target/x86_64-unknown-linux-musl/release bin/
           tar -czvf protofetch_linux_amd64.tar.gz bin/protofetch
 
       - name: Upload release

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -153,7 +153,7 @@ impl ProtofetchGitCache {
                         });
                     Ok(callbacks)
                 }
-                None => Err(AuthFailure),
+                None => Ok(callbacks),
             },
         }?;
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -153,7 +153,7 @@ impl ProtofetchGitCache {
                         });
                     Ok(callbacks)
                 }
-                None => Ok(callbacks),
+                None => Err(AuthFailure),
             },
         }?;
 


### PR DESCRIPTION
When releasing Linux binary, use switch `--target=x86_64-unknown-linux-musl` in order to get the binary working with various Linux distros (including alpine and older debian distros). So not require strict glibc dependency. It was failing in the service pipelines using debian images with the older glibc. 