### PR TITLE
Fix broken rustfmt check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
           toolchain: nightly
           components: rustfmt
 
-
       - name: Rustfmt
-        run: rustfmt +nightly --edition 2021 "$(find . -type f -iname "*.rs")"
+        run: cargo +nightly fmt --check
+
   linting:
     name: Linting
     runs-on: ubuntu-latest


### PR DESCRIPTION
Was broken in https://github.com/coralogix/protofetch/pull/55 by adding quotes.