### PR TITLE
Do not depend on nightly rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,21 +3,6 @@ on: [pull_request]
 name: CI
 
 jobs:
-  rustfmt_nightly:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Install nightly toolchain with rustfmt available
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: nightly
-          components: rustfmt
-
-
-      - name: Rustfmt
-        run: rustfmt +nightly --edition 2021 "$(find . -type f -iname "*.rs")"
   linting:
     name: Linting
     runs-on: ubuntu-latest
@@ -36,7 +21,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: "rustfmt, clippy"
+
+      - name: Run rustfmt
+        run: cargo fmt --check
+
       - name: Check that Cargo.lock is up-to-date
         uses: actions-rs/cargo@v1
         with:
@@ -53,6 +42,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
+
   ci-linux:
     name: CI Linux
     runs-on: ubuntu-latest
@@ -74,6 +64,7 @@ jobs:
           components: clippy
 
       - run: cargo test
+      
   ci-mac:
     name: CI MacOS
     runs-on: macos-latest

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,9 +1,2 @@
-overflow_delimited_expr = true
 newline_style = "Unix"
-imports_granularity = "Crate"
-reorder_impl_items = true
-fn_single_line = false
-blank_lines_upper_bound = 2
-comment_width = 110
 max_width = 100
-inline_attribute_width = 80

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -11,7 +11,8 @@ use crate::{
 };
 
 use crate::proto_repository::ProtoRepository;
-#[cfg(test)] use mockall::{predicate::*, *};
+#[cfg(test)]
+use mockall::{predicate::*, *};
 
 #[cfg_attr(test, automock)]
 pub trait RepositoryCache {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -15,7 +15,6 @@ use crate::{
 use std::iter::FromIterator;
 use thiserror::Error;
 
-
 #[derive(Error, Debug)]
 pub enum FetchError {
     #[error("Error while fetching repo from cache: {0}")]
@@ -328,19 +327,25 @@ fn remove_duplicates() {
     let mut input: HashMap<DependencyName, Vec<Revision>> = HashMap::new();
     let mut result: HashMap<DependencyName, Revision> = HashMap::new();
     let name = DependencyName::new("foo".to_string());
-    input.insert(name.clone(), vec![
-        Revision::Arbitrary {
-            revision: "1.0.0".to_string(),
-        },
+    input.insert(
+        name.clone(),
+        vec![
+            Revision::Arbitrary {
+                revision: "1.0.0".to_string(),
+            },
+            Revision::Arbitrary {
+                revision: "3.0.0".to_string(),
+            },
+            Revision::Arbitrary {
+                revision: "2.0.0".to_string(),
+            },
+        ],
+    );
+    result.insert(
+        name,
         Revision::Arbitrary {
             revision: "3.0.0".to_string(),
         },
-        Revision::Arbitrary {
-            revision: "2.0.0".to_string(),
-        },
-    ]);
-    result.insert(name, Revision::Arbitrary {
-        revision: "3.0.0".to_string(),
-    });
+    );
     assert_eq!(resolve_conflicts(input), result)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 #![allow(unused_doc_comments)]
 
-#[macro_use] extern crate strum;
-#[macro_use] extern crate log;
-#[macro_use] extern crate smart_default;
+#[macro_use]
+extern crate strum;
+#[macro_use]
+extern crate log;
+#[macro_use]
+extern crate smart_default;
 
 pub mod cache;
 pub mod cli;

--- a/src/proto_repository.rs
+++ b/src/proto_repository.rs
@@ -7,7 +7,8 @@ use crate::model::protofetch::{DependencyName, Descriptor, Revision};
 use git2::{Repository, ResetType};
 use thiserror::Error;
 
-#[cfg(test)] use mockall::{predicate::*, *};
+#[cfg(test)]
+use mockall::{predicate::*, *};
 
 #[derive(Error, Debug)]
 pub enum ProtoRepoError {


### PR DESCRIPTION
Nightly is a moving target, and the code that was properly formatted yesterday may be not formatted today. It also makes dev setup more complicated as you need both nightly and stable toolchains.

In the end, stable formatting is not so much worse, if at all.