### PR TITLE
Run CI workflow on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [pull_request]
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
 
 name: CI
 


### PR DESCRIPTION
We even have a badge in the readme displaying CI workflow status, but we don't run it.