### PR TITLE
Use the correct auth type depending on the actual protocol

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,12 +1,11 @@
 use std::path::{Path, PathBuf};
 
-use git2::{build::RepoBuilder, Cred, FetchOptions, RemoteCallbacks, Repository};
+use git2::Config;
+use git2::{build::RepoBuilder, Cred, CredentialType, FetchOptions, RemoteCallbacks, Repository};
 use thiserror::Error;
 
 use crate::{
-    cli::HttpGitAuth,
-    model::protofetch::{Coordinate, Protocol},
-    proto_repository::ProtoGitRepository,
+    cli::HttpGitAuth, model::protofetch::Coordinate, proto_repository::ProtoGitRepository,
 };
 
 use crate::proto_repository::ProtoRepository;
@@ -20,6 +19,7 @@ pub trait RepositoryCache {
 
 pub struct ProtofetchGitCache {
     pub location: PathBuf,
+    git_config: Config,
     git_auth: Option<HttpGitAuth>,
 }
 
@@ -42,7 +42,7 @@ impl RepositoryCache for ProtofetchGitCache {
             Some(path) => {
                 let mut repo = self.open_entry(&path)?;
 
-                self.fetch(&entry.protocol, &mut repo)?;
+                self.fetch(&mut repo)?;
 
                 repo
             }
@@ -55,13 +55,22 @@ impl RepositoryCache for ProtofetchGitCache {
 impl ProtofetchGitCache {
     pub fn new(
         location: PathBuf,
+        git_config: Config,
         git_auth: Option<HttpGitAuth>,
     ) -> Result<ProtofetchGitCache, CacheError> {
         if location.exists() && location.is_dir() {
-            Ok(ProtofetchGitCache { location, git_auth })
+            Ok(ProtofetchGitCache {
+                location,
+                git_config,
+                git_auth,
+            })
         } else if !location.exists() {
             std::fs::create_dir_all(&location)?;
-            Ok(ProtofetchGitCache { location, git_auth })
+            Ok(ProtofetchGitCache {
+                location,
+                git_config,
+                git_auth,
+            })
         } else {
             Err(CacheError::BadLocation {
                 location: location.to_str().unwrap_or("").to_string(),
@@ -89,10 +98,11 @@ impl ProtofetchGitCache {
             location: &Path,
             entry: &Coordinate,
             branch: &str,
-            auth: Option<HttpGitAuth>,
+            git_config: &Config,
+            auth: &Option<HttpGitAuth>,
         ) -> Result<Repository, CacheError> {
             let mut repo_builder = RepoBuilder::new();
-            let options = ProtofetchGitCache::fetch_options(&entry.protocol, auth)?;
+            let options = ProtofetchGitCache::fetch_options(git_config, auth)?;
             repo_builder
                 .bare(true)
                 .fetch_options(options)
@@ -107,51 +117,71 @@ impl ProtofetchGitCache {
         let branch = entry.branch.as_deref().unwrap_or("master");
         //Try to clone repo from master, otherwise try main
         //TODO: decide whether we actually want to actively choose the repo to checkout
-        clone_repo_inner(&self.location, entry, branch, self.git_auth.clone()).or_else(|_err| {
+        clone_repo_inner(
+            &self.location,
+            entry,
+            branch,
+            &self.git_config,
+            &self.git_auth,
+        )
+        .or_else(|_err| {
             warn!(
                 "Could not clone repo for branch {} with error {:?}, attempting to clone main",
                 branch, _err
             );
-            clone_repo_inner(&self.location, entry, "main", self.git_auth.clone())
+            clone_repo_inner(
+                &self.location,
+                entry,
+                "main",
+                &self.git_config,
+                &self.git_auth,
+            )
         })
     }
 
-    fn fetch(&self, protocol: &Protocol, repo: &mut Repository) -> Result<(), CacheError> {
+    fn fetch(&self, repo: &mut Repository) -> Result<(), CacheError> {
         let mut remote = repo.find_remote("origin")?;
         let refspecs: Vec<String> = remote
             .refspecs()
             .filter_map(|refspec| refspec.str().map(|s| s.to_string()))
             .collect();
-        let options = &mut ProtofetchGitCache::fetch_options(protocol, self.git_auth.clone())?;
+        let options = &mut ProtofetchGitCache::fetch_options(&self.git_config, &self.git_auth)?;
         remote.fetch(&refspecs, Some(options), None)?;
 
         Ok(())
     }
 
     fn fetch_options<'a>(
-        protocol: &Protocol,
-        auth: Option<HttpGitAuth>,
+        config: &'a Config,
+        auth: &'a Option<HttpGitAuth>,
     ) -> Result<FetchOptions<'a>, CacheError> {
         let mut callbacks = RemoteCallbacks::new();
-        match protocol {
-            Protocol::Ssh => {
-                trace!("Adding ssh callback for git fetch");
-                callbacks.credentials(|_url, username, _allowed_types| {
-                    Cred::ssh_key_from_agent(username.unwrap_or("git"))
-                });
+        // Consider using https://crates.io/crates/git2_credentials that supports
+        // more authentication options
+        callbacks.credentials(move |url, username, allowed_types| {
+            trace!(
+                "Requested credentials for {}, username {:?}, allowed types {:?}",
+                url,
+                username,
+                allowed_types
+            );
+            // Asking for ssh username
+            if allowed_types.contains(CredentialType::USERNAME) {
+                return Cred::username("git");
             }
-            Protocol::Https => {
+            // SSH auth
+            if allowed_types.contains(CredentialType::SSH_KEY) {
+                return Cred::ssh_key_from_agent(username.unwrap_or("git"));
+            }
+            // HTTP auth
+            if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
                 if let Some(auth) = auth {
-                    trace!(
-                        "Adding https callback with auth user {} for git fetch",
-                        auth.username
-                    );
-                    callbacks.credentials(move |_url, _username, _allowed_types| {
-                        Cred::userpass_plaintext(&auth.username, &auth.password)
-                    });
+                    return Cred::userpass_plaintext(&auth.username, &auth.password);
                 }
+                return Cred::credential_helper(config, url, username);
             }
-        };
+            Err(git2::Error::from_str("no valid authentication available"))
+        });
 
         let mut fetch_options = FetchOptions::new();
         fetch_options

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,6 @@
 use derive_new::new;
 use git2::Config;
-use std::{env, error::Error};
+use std::env;
 
 pub mod args;
 pub mod command_handlers;
@@ -21,33 +21,19 @@ impl HttpGitAuth {
     /// If 2FA is enabled please generate an access token and use it as password. Please see:
     /// https://github.blog/2013-09-03-two-factor-authentication/#how-does-it-work-for-command-line-git
     pub fn resolve_git_auth(
+        config: &Config,
         cli_username: Option<String>,
         cli_password: Option<String>,
-    ) -> Result<Option<HttpGitAuth>, Box<dyn Error>> {
-        let cfg = Config::open_default()?;
+    ) -> Option<HttpGitAuth> {
         let username = cli_username
             .or_else(|| env::var("GIT_USERNAME").ok())
-            .or_else(|| cfg.get_string("user.name").ok());
+            .or_else(|| config.get_string("user.name").ok());
         let password = cli_password
             .or_else(|| env::var("GIT_PASSWORD").ok())
-            .or_else(|| cfg.get_string("user.password").ok());
+            .or_else(|| config.get_string("user.password").ok());
         match (username, password) {
-            (Some(username), Some(password)) => Ok(Some(HttpGitAuth { username, password })),
-            (Some(username), None) => {
-                warn!("Git user {} found but no password found for git auth, which is used for fetching via https. \
-                 If you are using https please pass as command line, GIT_PASSWORD env variable or add to git config.", username);
-                Ok(None)
-            }
-            (None, Some(password)) => {
-                warn!("Git password {} found but no user found for git auth, which is used for fetching via https. \
-                If you are using https please pass as command line, GIT_USERNAME env variable or add to git config.", password);
-                Ok(None)
-            }
-            _ => {
-                warn!("No git auth found, used for fetching via https. If you are using https please pass as \
-                command line parameters, GIT_USERNAME and GIT_PASSWORD env variables or add to git config.");
-                Ok(None)
-            }
+            (Some(username), Some(password)) => Some(HttpGitAuth { username, password }),
+            _ => None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::{
 use clap::Parser;
 use env_logger::Target;
 
+use git2::Config;
 use protofetch::{
     cache::ProtofetchGitCache,
     cli,
@@ -27,7 +28,8 @@ fn run() -> Result<(), Box<dyn Error>> {
     let home_dir =
         home::home_dir().expect("Could not find home dir. Please define $HOME env variable.");
     let cache_path = home_dir.join(PathBuf::from(&cli_args.cache_directory));
-    let git_auth = HttpGitAuth::resolve_git_auth(cli_args.username, cli_args.password)?;
+    let git_config = Config::open_default()?;
+    let git_auth = HttpGitAuth::resolve_git_auth(&git_config, cli_args.username, cli_args.password);
     let cache = ProtofetchGitCache::new(cache_path, git_auth)?;
     let module_path = Path::new(&cli_args.module_location);
     let lockfile_path = Path::new(&cli_args.lockfile_location);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn run() -> Result<(), Box<dyn Error>> {
     let cache_path = home_dir.join(PathBuf::from(&cli_args.cache_directory));
     let git_config = Config::open_default()?;
     let git_auth = HttpGitAuth::resolve_git_auth(&git_config, cli_args.username, cli_args.password);
-    let cache = ProtofetchGitCache::new(cache_path, git_auth)?;
+    let cache = ProtofetchGitCache::new(cache_path, git_config, git_auth)?;
     let module_path = Path::new(&cli_args.module_location);
     let lockfile_path = Path::new(&cli_args.lockfile_location);
     let proto_output_directory = Path::new(&cli_args.output_proto_directory);


### PR DESCRIPTION
1. Do not warn about missing `GIT_USERNAME` and `GIT_PASSWORD` when we don't even know if we need them.
2. Use auth type for the actual protocol used by git, not for what we assume based on protofetch configuration. Git allows overriding repository URL, and it's not uncommon to have something like `url.git@github.com:.insteadof=https://github.com/`, when protofetch thinks it uses HTTPS, but libgit2 actually uses SSH.
3. Use git credential helper if we need HTTPS credentials and they have not been passed to protofetch explicitly.
4. Allow accessing public repositories by HTTPS without credentials (closes #34).

There is a [git2_credentials](https://crates.io/crates/git2_credentials) crate that supports git authentication even better (for example, it can get SSH username and identity from the git configuration), but this crate hasn't been updated yet to support git2 0.17 which we use.

In general, we should probably deprecate and eventually stop supporting `GIT_USERNAME` and `GIT_PASSWORD`. These variables imply that the whole tree of proto files can be accessed using the same credentials, which is not necessarily true.