### PR TITLE
Do not pretend like we have an aarch64-darwin build

### DIFF
--- a/.github/npm/getBinary.js
+++ b/.github/npm/getBinary.js
@@ -22,7 +22,8 @@ function getPlatform() {
 	}
 
 	if (type === 'Darwin' && arch === 'arm64') {
-		return 'darwin_arm64';
+		// This requires Rosetta
+		return 'darwin_amd64';
 	}
 
 	throw new Error(`Unsupported platform: ${type} ${arch}. Please create an issue at https://github.com/coralogix/protofetch/issues`);
@@ -31,7 +32,7 @@ function getPlatform() {
 function getBinary() {
 	const platform = getPlatform();
 	const version = require('./package.json').version;
-	const url = `https://github.com/coralogix/protofetch/releases/download/v${ version }/protofetch_${ platform }.tar.gz`;
+	const url = `https://github.com/coralogix/protofetch/releases/download/v${version}/protofetch_${platform}.tar.gz`;
 	const name = 'protofetch';
 
 	return new Binary(name, url)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,41 +69,7 @@ jobs:
           files: |
            protofetch_${{ matrix.target }}.tar.gz
 
-  release-mac-arm:
-    runs-on: macos-latest
-    needs: tests
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v1.0.1
-        with:
-          path: target
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-
-
-      - name: Install stable toolchain mac-arm64
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.70.0
-          target: aarch64-apple-darwin
-
-      - name: Build for release mac-arm64
-        # We would need self-hosted arm runner for the correct target - for now we use `vendored-openssl` feature on `git2-rs dependency to overcome it
-        run: |
-          cargo build --release # --target=aarch64-apple-darwin
-          mv target/release bin/
-          tar -czvf protofetch_darwin_arm64.tar.gz bin/protofetch
-
-      - name: Upload release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-           protofetch_darwin_arm64.tar.gz
-
-  release-mac-amd:
+  release-mac:
     runs-on: macos-latest
     needs: tests
     steps:
@@ -171,7 +137,7 @@ jobs:
 
   npm-release:
     runs-on: ubuntu-latest
-    needs: [ release-mac-amd, release-mac-arm, release-linux, release-windows, tests ]
+    needs: [ release-mac, release-linux, release-windows, tests ]
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
"darwin_arm64" binaries we distribute are actually "darwin_amd64", and there is no easy way to cross-build to aarch64 because of the native dependencies.