### PR TITLE
Bump cargo package version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,7 +787,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.0.22"
+version = "0.0.23"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.0.22"
+version = "0.0.23"
 edition = "2021"
 license = "Apache-2.0"
 description = "A source dependency management tool for Protobuf."


### PR DESCRIPTION
0.0.22 seems to be partially released (on cargo, but not on npm). Let's bump the version one more time to perform a clean release from the latest code.