### PR TITLE
Replace extern crate with use

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use git2::Config;
 use git2::{build::RepoBuilder, Cred, CredentialType, FetchOptions, RemoteCallbacks, Repository};
+use log::{trace, warn};
 use thiserror::Error;
 
 use crate::{

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -1,3 +1,5 @@
+use log::info;
+
 use crate::{
     cache::ProtofetchGitCache,
     fetch,

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     proto_repository::ProtoRepository,
 };
+use log::{debug, error, info};
 use std::iter::FromIterator;
 use thiserror::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,3 @@
-#![allow(unused_doc_comments)]
-
-#[macro_use]
-extern crate strum;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate smart_default;
-
 pub mod cache;
 pub mod cli;
 pub mod fetch;

--- a/src/model/protodep.rs
+++ b/src/model/protodep.rs
@@ -5,6 +5,7 @@ use crate::model::{
     },
     ParseError,
 };
+use log::{debug, error};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path, str::FromStr};
 use toml::Value;

--- a/src/model/protofetch.rs
+++ b/src/model/protofetch.rs
@@ -1,16 +1,18 @@
 use derive_new::new;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+use smart_default::SmartDefault;
 use std::{
     cmp::Ordering,
     collections::HashMap,
     fmt::{Debug, Display},
     path::{Path, PathBuf},
 };
+use strum::EnumString;
 
 use crate::model::ParseError;
 use lazy_static::lazy_static;
-use log::debug;
+use log::{debug, error};
 use std::{collections::BTreeSet, hash::Hash};
 use toml::{map::Map, Value};
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,5 +1,6 @@
 use crate::model::protofetch::{AllowPolicies, DenyPolicies, LockFile, LockedDependency};
 use derive_new::new;
+use log::{debug, info, trace};
 use std::{
     collections::HashSet,
     fs::File,
@@ -189,7 +190,7 @@ fn pruned_transitive_dependencies(
         }
     }
 
-    /// Select proto files for the transitive dependencies of this dependency
+    // Select proto files for the transitive dependencies of this dependency
     let t_deps: Vec<LockedDependency> = collect_transitive_dependencies(dep, lockfile);
     for t_dep in t_deps {
         trace!(

--- a/src/proto_repository.rs
+++ b/src/proto_repository.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::model::protofetch::{DependencyName, Descriptor, Revision};
 use git2::{Repository, ResetType};
+use log::{debug, info};
 use thiserror::Error;
 
 #[cfg(test)]


### PR DESCRIPTION
https://doc.rust-lang.org/reference/names/preludes.html#extern-prelude
> Beginning in the 2018 edition <...> it is considered unidiomatic to use extern crate.