### PR TITLE
Move tests to the test configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,42 +61,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "cc"
@@ -173,54 +136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "config"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
-dependencies = [
- "async-trait",
- "json5",
- "lazy_static",
- "nom",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde",
- "serde_json",
- "toml 0.5.11",
- "yaml-rust",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,32 +147,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "downcast"
@@ -330,27 +223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "git2"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,9 +242,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "heck"
@@ -454,29 +323,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
 name = "jobserver"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
 ]
 
 [[package]]
@@ -532,12 +384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,12 +400,6 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mockall"
@@ -586,16 +426,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -648,79 +478,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
-dependencies = [
- "dlv-list",
- "hashbrown",
-]
-
-[[package]]
-name = "output_vt100"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "pathdiff"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
-
-[[package]]
-name = "pest"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
-dependencies = [
- "thiserror",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.18",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
-dependencies = [
- "once_cell",
- "pest",
- "sha2",
-]
 
 [[package]]
 name = "pkg-config"
@@ -759,18 +520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pretty_assertions"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
-dependencies = [
- "ctor",
- "diff",
- "output_vt100",
- "yansi",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,7 +539,6 @@ name = "protofetch"
 version = "0.0.23"
 dependencies = [
  "clap",
- "config",
  "derive-new",
  "env_logger",
  "git2",
@@ -798,7 +546,6 @@ dependencies = [
  "lazy_static",
  "log",
  "mockall",
- "pretty_assertions",
  "project-root",
  "regex",
  "serde",
@@ -806,7 +553,7 @@ dependencies = [
  "strum",
  "test-log",
  "thiserror",
- "toml 0.7.4",
+ "toml",
 ]
 
 [[package]]
@@ -836,27 +583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
-name = "ron"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
-dependencies = [
- "base64",
- "bitflags",
- "serde",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
-
-[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,12 +601,6 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
-
-[[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
@@ -903,34 +623,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.96"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
 ]
 
 [[package]]
@@ -1011,9 +709,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-log"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
+checksum = "d9601d162c1d77e62c1ea0bc8116cd1caf143ce3af947536c3c9052a1677fe0c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1057,15 +755,6 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
@@ -1097,18 +786,6 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-bidi"
@@ -1153,18 +830,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -1271,18 +936,3 @@ checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
-name = "yansi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ vendored-libgit2 = ["git2/vendored-libgit2"]
 
 [dependencies]
 clap = { version = "4.3.2", features = ["derive"] }
-config = "0.13.3"
 derive-new = "0.5.9"
 env_logger = "0.10.0"
 git2 = "0.17.2"
@@ -30,11 +29,10 @@ regex = "1.8.4"
 serde = { version = "1.0.163", features = ["derive"] }
 smart-default = "0.7.1"
 strum = { version = "0.24.1", features = ["derive"] }
-test-log = "0.2.11"
 thiserror = "1.0.40"
 toml = "0.7.4"
 
 [dev-dependencies]
 mockall = "0.11.4"
-pretty_assertions = "1.3.0"
 project-root = "0.2.2"
+test-log = "0.2.11"

--- a/src/model/protodep.rs
+++ b/src/model/protodep.rs
@@ -99,9 +99,13 @@ impl ProtodepDescriptor {
     }
 }
 
-#[test]
-fn load_valid_file_one_dep() {
-    let str = r#"
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_valid_file_one_dep() {
+        let str = r#"
 proto_outdir = "./proto_out"
 
 [[dependencies]]
@@ -111,26 +115,26 @@ proto_outdir = "./proto_out"
   revision = "1.0.0"
 "#;
 
-    let expected = ProtodepDescriptor {
-        proto_out_dir: "./proto_out".to_string(),
-        dependencies: vec![Dependency {
-            target: "github.com/opensaasstudio/plasma/protobuf".to_string(),
-            subgroup: None,
-            branch: Some("master".to_string()),
-            revision: "1.0.0".to_string(),
-            path: None,
-            ignores: vec![],
-            includes: vec![],
-            protocol: "ssh".to_string(),
-        }],
-    };
+        let expected = ProtodepDescriptor {
+            proto_out_dir: "./proto_out".to_string(),
+            dependencies: vec![Dependency {
+                target: "github.com/opensaasstudio/plasma/protobuf".to_string(),
+                subgroup: None,
+                branch: Some("master".to_string()),
+                revision: "1.0.0".to_string(),
+                path: None,
+                ignores: vec![],
+                includes: vec![],
+                protocol: "ssh".to_string(),
+            }],
+        };
 
-    assert_eq!(ProtodepDescriptor::from_toml_str(str).unwrap(), expected);
-}
+        assert_eq!(ProtodepDescriptor::from_toml_str(str).unwrap(), expected);
+    }
 
-#[test]
-fn load_valid_file_multiple_dep() {
-    let str = r#"
+    #[test]
+    fn load_valid_file_multiple_dep() {
+        let str = r#"
 proto_outdir = "./proto_out"
 
 [[dependencies]]
@@ -151,59 +155,59 @@ proto_outdir = "./proto_out"
   revision = "3.0.0"
 "#;
 
-    let expected = ProtodepDescriptor {
-        proto_out_dir: "./proto_out".to_string(),
-        dependencies: vec![
-            Dependency {
-                target: "github.com/opensaasstudio/plasma/protobuf".to_string(),
-                subgroup: None,
-                branch: Some("master".to_string()),
-                revision: "1.0.0".to_string(),
-                path: None,
-                ignores: vec![],
-                includes: vec![],
-                protocol: "ssh".to_string(),
-            },
-            Dependency {
-                target: "github.com/opensaasstudio/plasma1/protobuf".to_string(),
-                subgroup: None,
-                branch: Some("master".to_string()),
-                revision: "2.0.0".to_string(),
-                path: None,
-                ignores: vec![],
-                includes: vec![],
-                protocol: "https".to_string(),
-            },
-            Dependency {
-                target: "github.com/opensaasstudio/plasma2/protobuf".to_string(),
-                subgroup: None,
-                branch: None,
-                revision: "3.0.0".to_string(),
-                path: None,
-                ignores: vec![],
-                includes: vec![],
-                protocol: "ssh".to_string(),
-            },
-        ],
-    };
+        let expected = ProtodepDescriptor {
+            proto_out_dir: "./proto_out".to_string(),
+            dependencies: vec![
+                Dependency {
+                    target: "github.com/opensaasstudio/plasma/protobuf".to_string(),
+                    subgroup: None,
+                    branch: Some("master".to_string()),
+                    revision: "1.0.0".to_string(),
+                    path: None,
+                    ignores: vec![],
+                    includes: vec![],
+                    protocol: "ssh".to_string(),
+                },
+                Dependency {
+                    target: "github.com/opensaasstudio/plasma1/protobuf".to_string(),
+                    subgroup: None,
+                    branch: Some("master".to_string()),
+                    revision: "2.0.0".to_string(),
+                    path: None,
+                    ignores: vec![],
+                    includes: vec![],
+                    protocol: "https".to_string(),
+                },
+                Dependency {
+                    target: "github.com/opensaasstudio/plasma2/protobuf".to_string(),
+                    subgroup: None,
+                    branch: None,
+                    revision: "3.0.0".to_string(),
+                    path: None,
+                    ignores: vec![],
+                    includes: vec![],
+                    protocol: "ssh".to_string(),
+                },
+            ],
+        };
 
-    assert_eq!(ProtodepDescriptor::from_toml_str(str).unwrap(), expected);
-}
+        assert_eq!(ProtodepDescriptor::from_toml_str(str).unwrap(), expected);
+    }
 
-#[test]
-fn load_valid_file_no_dep() {
-    let str = r#"proto_outdir = "./proto_out""#;
-    let expected = ProtodepDescriptor {
-        proto_out_dir: "./proto_out".to_string(),
-        dependencies: vec![],
-    };
+    #[test]
+    fn load_valid_file_no_dep() {
+        let str = r#"proto_outdir = "./proto_out""#;
+        let expected = ProtodepDescriptor {
+            proto_out_dir: "./proto_out".to_string(),
+            dependencies: vec![],
+        };
 
-    assert_eq!(ProtodepDescriptor::from_toml_str(str).unwrap(), expected);
-}
+        assert_eq!(ProtodepDescriptor::from_toml_str(str).unwrap(), expected);
+    }
 
-#[test]
-fn migrate_protodep_to_protofetch_file() {
-    let protodep_toml = r#"
+    #[test]
+    fn migrate_protodep_to_protofetch_file() {
+        let protodep_toml = r#"
 proto_outdir = "./proto_out"
 
 [[dependencies]]
@@ -213,7 +217,7 @@ proto_outdir = "./proto_out"
   revision = "1.5.0"
 "#;
 
-    let protofetch_toml = r#"
+        let protofetch_toml = r#"
 name = "generated"
 description = "Generated from protodep file"
 proto_out_dir = "./proto_out"
@@ -222,13 +226,14 @@ proto_out_dir = "./proto_out"
   protocol = "ssh"
   revision = "1.5.0"
 "#;
-    let descriptor = ProtodepDescriptor::from_toml_str(protodep_toml)
-        .unwrap()
-        .to_proto_fetch()
-        .unwrap();
-    let toml = toml::to_string(&descriptor.to_toml()).unwrap();
+        let descriptor = ProtodepDescriptor::from_toml_str(protodep_toml)
+            .unwrap()
+            .to_proto_fetch()
+            .unwrap();
+        let toml = toml::to_string(&descriptor.to_toml()).unwrap();
 
-    let expected = Descriptor::from_toml_str(protofetch_toml).unwrap();
-    let result = Descriptor::from_toml_str(&toml).unwrap();
-    assert_eq!(result, expected);
+        let expected = Descriptor::from_toml_str(protofetch_toml).unwrap();
+        let result = Descriptor::from_toml_str(&toml).unwrap();
+        assert_eq!(result, expected);
+    }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -428,7 +428,7 @@ fn path_strip_prefix(path: &Path, prefix: &Path) -> Result<PathBuf, ProtoError> 
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::{model::protofetch::*, proto::*};
     use std::{
         collections::{BTreeSet, HashSet},
@@ -437,7 +437,7 @@ mod test {
     use test_log::test;
 
     #[test]
-    fn content_root_dependencies_test() {
+    fn content_root_dependencies() {
         let cache_dir = project_root::get_project_root()
             .unwrap()
             .join(Path::new("resources/cache/dep3/hash3"));
@@ -471,7 +471,7 @@ mod test {
     }
 
     #[test]
-    fn pruned_dependencies_test() {
+    fn pruned_dependencies() {
         let cache_dir = project_root::get_project_root()
             .unwrap()
             .join(Path::new("resources/cache"));
@@ -602,7 +602,7 @@ mod test {
     }
 
     #[test]
-    fn collect_all_root_dependencies_test() {
+    fn collect_all_root_dependencies_() {
         let lock_file = LockFile {
             module_name: "test".to_string(),
             proto_out_dir: None,
@@ -636,7 +636,7 @@ mod test {
     }
 
     #[test]
-    fn collect_all_root_dependencies_test_filtered() {
+    fn collect_all_root_dependencies_filtered() {
         let lock_file = LockFile {
             module_name: "test".to_string(),
             proto_out_dir: None,


### PR DESCRIPTION
Mostly by simply wrapping them into `#[cfg(test)] mod tests { ... }`.
Besides following the common rust practices, this removes test-log dependency from the compile scope.