### PR TITLE
Deprecate explicit HTTP credentials

### DIFF
--- a/src/api/builder.rs
+++ b/src/api/builder.rs
@@ -14,8 +14,7 @@ pub struct ProtofetchBuilder {
     output_directory_name: Option<PathBuf>,
 
     // These fields are deprecated
-    http_username: Option<String>,
-    http_password: Option<String>,
+    http_credentials: Option<HttpGitAuth>,
     cache_dependencies_directory_name: Option<PathBuf>,
 }
 
@@ -64,9 +63,8 @@ impl ProtofetchBuilder {
         note = "configure credentials using standard git configuration instead"
     )]
     #[doc(hidden)]
-    pub fn http_credentials(mut self, username: Option<String>, password: Option<String>) -> Self {
-        self.http_username = username;
-        self.http_password = password;
+    pub fn http_credentials(mut self, username: String, password: String) -> Self {
+        self.http_credentials = Some(HttpGitAuth::new(username, password));
         self
     }
 
@@ -87,8 +85,7 @@ impl ProtofetchBuilder {
             lock_file_name,
             output_directory_name,
             cache_directory_path,
-            http_username,
-            http_password,
+            http_credentials,
             cache_dependencies_directory_name,
         } = self;
         let root = match root {
@@ -104,9 +101,6 @@ impl ProtofetchBuilder {
             root.join(cache_directory_path.unwrap_or_else(default_cache_directory));
 
         let git_config = git2::Config::open_default()?;
-
-        let http_credentials =
-            HttpGitAuth::resolve_git_auth(&git_config, http_username, http_password);
 
         let cache = ProtofetchGitCache::new(cache_directory, git_config, http_credentials)?;
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,4 @@
 use derive_new::new;
-use git2::Config;
-use std::env;
 
 pub mod command_handlers;
 
@@ -8,31 +6,4 @@ pub mod command_handlers;
 pub struct HttpGitAuth {
     pub username: String,
     pub password: String,
-}
-
-impl HttpGitAuth {
-    /// Resolve git auth for fetching git repos using https.
-    /// Tries to get username and password in the following order.
-    /// 1 - From command line arguments (--username, --password)
-    /// 2 - From env variables: GIT_USERNAME, GIT_PASSWORD
-    /// 3 - From default git config: user.name, user.password
-    ///
-    /// If 2FA is enabled please generate an access token and use it as password. Please see:
-    /// https://github.blog/2013-09-03-two-factor-authentication/#how-does-it-work-for-command-line-git
-    pub fn resolve_git_auth(
-        config: &Config,
-        cli_username: Option<String>,
-        cli_password: Option<String>,
-    ) -> Option<HttpGitAuth> {
-        let username = cli_username
-            .or_else(|| env::var("GIT_USERNAME").ok())
-            .or_else(|| config.get_string("user.name").ok());
-        let password = cli_password
-            .or_else(|| env::var("GIT_PASSWORD").ok())
-            .or_else(|| config.get_string("user.password").ok());
-        match (username, password) {
-            (Some(username), Some(password)) => Some(HttpGitAuth { username, password }),
-            _ => None,
-        }
-    }
 }


### PR DESCRIPTION
It shouldn't be necessary to have credentials specified explicitly for protofetch, they should be part of the git configuration instead.

- `user.name` and `user.password` will not be read at all. I doubt anyone used it, as `user.name` is usually set to the first and last name of a person.
- `GIT_USERNAME` and `GIT_PASSWORD` will not work when using the API.
- `--username`, `--password`, `GIT_USERNAME` and `GIT_PASSWORD` will work in the CLI, but trigger a warning.