### PR TITLE
Fix artifacts not attached to GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v3
         with:
-          path: |
-            protofetch_${{ matrix.target }}.tar.gz
+          name: packages
+          path: protofetch_${{ matrix.target }}.tar.gz
 
   package-mac:
     runs-on: macos-latest
@@ -111,8 +111,8 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v3
         with:
-          path: |
-            protofetch_darwin_amd64.tar.gz
+          name: packages
+          path: protofetch_darwin_amd64.tar.gz
 
   package-windows:
     runs-on: windows-latest
@@ -136,8 +136,8 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v3
         with:
-          path: |
-            protofetch_win64.tar.gz
+          name: packages
+          path: protofetch_win64.tar.gz
 
   release:
     runs-on: ubuntu-latest
@@ -166,6 +166,8 @@ jobs:
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
+        with:
+          name: packages
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
`actions/download-artifact` creates subdirectories unless we download a specific artifact, so let's give it a meaningful name.