### PR TITLE
Make revision field optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +526,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,9 +559,9 @@ dependencies = [
  "env_logger",
  "git2",
  "home",
- "lazy_static",
  "log",
  "mockall",
+ "pretty_assertions",
  "project-root",
  "regex",
  "serde",
@@ -936,3 +952,9 @@ checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,7 @@ repository = "https://github.com/coralogix/protofetch"
 readme = "README.md"
 keywords = ["proto", "cli", "protobuf", "dependency-manager", "grpc"]
 categories = ["command-line-utilities"]
-exclude = [
-    ".github", ".gitignore"
-]
+exclude = [".github", ".gitignore"]
 
 [features]
 vendored-openssl = ["git2/vendored-openssl"]
@@ -23,7 +21,6 @@ derive-new = "0.5.9"
 env_logger = "0.10.0"
 git2 = "0.17.2"
 home = "0.5.5"
-lazy_static = "1.4.0"
 log = "0.4.18"
 regex = "1.8.4"
 serde = { version = "1.0.163", features = ["derive"] }
@@ -34,5 +31,6 @@ toml = "0.7.4"
 
 [dev-dependencies]
 mockall = "0.11.4"
+pretty_assertions = "1.4.0"
 project-root = "0.2.2"
 test-log = "0.2.11"

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -242,7 +242,7 @@ mod tests {
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Arbitrary {
+                    revision: Revision::Fixed {
                         revision: "1.0.0".to_string(),
                     },
                     rules: Default::default(),
@@ -256,7 +256,7 @@ mod tests {
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Arbitrary {
+                    revision: Revision::Fixed {
                         revision: "2.0.0".to_string(),
                     },
                     rules: Rules {
@@ -290,7 +290,7 @@ mod tests {
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Arbitrary {
+                    revision: Revision::Fixed {
                         revision: "3.0.0".to_string(),
                     },
                     rules: Default::default(),
@@ -339,20 +339,20 @@ mod tests {
         input.insert(
             name.clone(),
             vec![
-                Revision::Arbitrary {
+                Revision::Fixed {
                     revision: "1.0.0".to_string(),
                 },
-                Revision::Arbitrary {
+                Revision::Fixed {
                     revision: "3.0.0".to_string(),
                 },
-                Revision::Arbitrary {
+                Revision::Fixed {
                     revision: "2.0.0".to_string(),
                 },
             ],
         );
         result.insert(
             name,
-            Revision::Arbitrary {
+            Revision::Fixed {
                 revision: "3.0.0".to_string(),
             },
         );

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -242,7 +242,7 @@ mod tests {
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Fixed {
+                    revision: Revision::Pinned {
                         revision: "1.0.0".to_string(),
                     },
                     rules: Default::default(),
@@ -256,7 +256,7 @@ mod tests {
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Fixed {
+                    revision: Revision::Pinned {
                         revision: "2.0.0".to_string(),
                     },
                     rules: Rules {
@@ -290,7 +290,7 @@ mod tests {
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Fixed {
+                    revision: Revision::Pinned {
                         revision: "3.0.0".to_string(),
                     },
                     rules: Default::default(),
@@ -339,20 +339,20 @@ mod tests {
         input.insert(
             name.clone(),
             vec![
-                Revision::Fixed {
+                Revision::Pinned {
                     revision: "1.0.0".to_string(),
                 },
-                Revision::Fixed {
+                Revision::Pinned {
                     revision: "3.0.0".to_string(),
                 },
-                Revision::Fixed {
+                Revision::Pinned {
                     revision: "2.0.0".to_string(),
                 },
             ],
         );
         result.insert(
             name,
-            Revision::Fixed {
+            Revision::Pinned {
                 revision: "3.0.0".to_string(),
             },
         );

--- a/src/model/protodep.rs
+++ b/src/model/protodep.rs
@@ -72,7 +72,7 @@ impl ProtodepDescriptor {
         fn convert_dependency(d: Dependency) -> Result<ProtofetchDependency, ParseError> {
             let protocol: Protocol = Protocol::from_str(&d.protocol)?;
             let coordinate = Coordinate::from_url(d.target.as_str(), protocol, d.branch)?;
-            let revision = Revision::Fixed {
+            let revision = Revision::Pinned {
                 revision: d.revision,
             };
             let name = DependencyName::new(coordinate.repository.clone());

--- a/src/model/protodep.rs
+++ b/src/model/protodep.rs
@@ -72,7 +72,7 @@ impl ProtodepDescriptor {
         fn convert_dependency(d: Dependency) -> Result<ProtofetchDependency, ParseError> {
             let protocol: Protocol = Protocol::from_str(&d.protocol)?;
             let coordinate = Coordinate::from_url(d.target.as_str(), protocol, d.branch)?;
-            let revision = Revision::Arbitrary {
+            let revision = Revision::Fixed {
                 revision: d.revision,
             };
             let name = DependencyName::new(coordinate.repository.clone());

--- a/src/model/protofetch.rs
+++ b/src/model/protofetch.rs
@@ -142,7 +142,7 @@ impl Display for Protocol {
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum Revision {
-    Fixed { revision: String },
+    Pinned { revision: String },
     Arbitrary,
 }
 
@@ -427,7 +427,7 @@ impl Descriptor {
             dependency.insert("url".to_string(), Value::String(d.coordinate.to_string()));
             match d.revision {
                 Revision::Arbitrary => (),
-                Revision::Fixed { revision } => {
+                Revision::Pinned { revision } => {
                     dependency.insert("revision".to_owned(), Value::String(revision.to_owned()));
                 }
             }
@@ -514,7 +514,7 @@ fn parse_policies(toml: &Value, source: &str) -> Result<BTreeSet<FilePolicy>, Pa
 fn parse_revision(value: &toml::Value) -> Result<Revision, ParseError> {
     let revstring = value.clone().try_into::<String>()?;
 
-    Ok(Revision::Fixed {
+    Ok(Revision::Pinned {
         revision: revstring,
     })
 }
@@ -626,7 +626,7 @@ mod tests {
                     protocol: Protocol::Https,
                     branch: None,
                 },
-                revision: Revision::Fixed {
+                revision: Revision::Pinned {
                     revision: "1.0.0".to_string(),
                 },
                 rules: Default::default(),
@@ -693,7 +693,7 @@ mod tests {
                     protocol: Protocol::Https,
                     branch: None,
                 },
-                revision: Revision::Fixed {
+                revision: Revision::Pinned {
                     revision: "1.0.0".to_string(),
                 },
                 rules: Rules {
@@ -763,7 +763,7 @@ mod tests {
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Fixed {
+                    revision: Revision::Pinned {
                         revision: "1.0.0".to_string(),
                     },
                     rules: Default::default(),
@@ -777,7 +777,7 @@ mod tests {
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Fixed {
+                    revision: Revision::Pinned {
                         revision: "2.0.0".to_string(),
                     },
                     rules: Default::default(),
@@ -791,7 +791,7 @@ mod tests {
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Fixed {
+                    revision: Revision::Pinned {
                         revision: "3.0.0".to_string(),
                     },
                     rules: Default::default(),

--- a/src/model/protofetch.rs
+++ b/src/model/protofetch.rs
@@ -425,11 +425,8 @@ impl Descriptor {
                 Value::String(d.coordinate.protocol.to_string()),
             );
             dependency.insert("url".to_string(), Value::String(d.coordinate.to_string()));
-            match d.revision {
-                Revision::Arbitrary => (),
-                Revision::Pinned { revision } => {
-                    dependency.insert("revision".to_owned(), Value::String(revision.to_owned()));
-                }
+            if let Revision::Pinned { revision } = d.revision {
+                dependency.insert("revision".to_owned(), Value::String(revision.to_owned()));
             }
             description.insert(d.name.value, Value::Table(dependency));
         }

--- a/src/model/protofetch.rs
+++ b/src/model/protofetch.rs
@@ -11,7 +11,6 @@ use std::{
 use strum::EnumString;
 
 use crate::model::ParseError;
-use lazy_static::lazy_static;
 use log::{debug, error};
 use std::{collections::BTreeSet, hash::Hash};
 use toml::{map::Map, Value};
@@ -141,46 +140,10 @@ impl Display for Protocol {
     }
 }
 
-#[derive(Serialize, Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum Revision {
-    #[allow(dead_code)]
-    Semver {
-        major: SemverComponent,
-        minor: SemverComponent,
-        patch: SemverComponent,
-    },
-    Arbitrary {
-        revision: String,
-    },
-}
-
-impl Display for Revision {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Revision::Semver {
-                major,
-                minor,
-                patch,
-            } => write!(f, "{major}.{minor}.{patch}"),
-            Revision::Arbitrary { revision } => f.write_str(revision),
-        }
-    }
-}
-
-#[derive(Serialize, Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
-#[allow(dead_code)]
-pub enum SemverComponent {
-    Fixed(u8),
-    Wildcard,
-}
-
-impl Display for SemverComponent {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            SemverComponent::Fixed(c) => write!(f, "{c}"),
-            SemverComponent::Wildcard => f.write_str("*"),
-        }
-    }
+    Fixed { revision: String },
+    Arbitrary,
 }
 
 #[derive(new, Clone, Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq, Hash)]
@@ -381,7 +344,7 @@ pub struct DependencyName {
     pub value: String,
 }
 
-#[derive(new, Serialize, Debug, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(new, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct Dependency {
     pub name: DependencyName,
     pub coordinate: Coordinate,
@@ -389,7 +352,7 @@ pub struct Dependency {
     pub rules: Rules,
 }
 
-#[derive(new, Serialize, PartialEq, Debug, PartialOrd, Ord, Eq)]
+#[derive(new, PartialEq, Debug, PartialOrd, Ord, Eq)]
 pub struct Descriptor {
     pub name: String,
     pub description: Option<String>,
@@ -462,10 +425,12 @@ impl Descriptor {
                 Value::String(d.coordinate.protocol.to_string()),
             );
             dependency.insert("url".to_string(), Value::String(d.coordinate.to_string()));
-            dependency.insert(
-                "revision".to_string(),
-                Value::String(d.revision.to_string()),
-            );
+            match d.revision {
+                Revision::Arbitrary => (),
+                Revision::Fixed { revision } => {
+                    dependency.insert("revision".to_owned(), Value::String(revision.to_owned()));
+                }
+            }
             description.insert(d.name.value, Value::Table(dependency));
         }
         Value::Table(description)
@@ -491,11 +456,10 @@ fn parse_dependency(name: String, value: &toml::Value) -> Result<Dependency, Par
         .and_then(|x| x.clone().try_into::<String>().map_err(|e| e.into()))
         .and_then(|url| Coordinate::from_url(&url, protocol, branch))?;
 
-    let revision = parse_revision(
-        value
-            .get("revision")
-            .ok_or_else(|| ParseError::MissingKey("revision".to_string()))?,
-    )?;
+    let revision = match value.get("revision") {
+        Some(revision) => parse_revision(revision)?,
+        None => Revision::Arbitrary,
+    };
 
     let prune = value
         .get("prune")
@@ -547,46 +511,12 @@ fn parse_policies(toml: &Value, source: &str) -> Result<BTreeSet<FilePolicy>, Pa
         .collect::<Result<BTreeSet<_>, _>>()
 }
 
-lazy_static! {
-    static ref SEMVER_REGEX: Regex =
-        Regex::new(r"^v?(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?$").unwrap();
-}
-
 fn parse_revision(value: &toml::Value) -> Result<Revision, ParseError> {
     let revstring = value.clone().try_into::<String>()?;
 
-    Ok(Revision::Arbitrary {
+    Ok(Revision::Fixed {
         revision: revstring,
     })
-}
-
-fn _parse_semver(revstring: &str) -> Result<Revision, ParseError> {
-    let results = SEMVER_REGEX.captures(revstring);
-
-    Ok(
-        match (
-            results.as_ref().and_then(|c| c.name("major")),
-            results.as_ref().and_then(|c| c.name("minor")),
-            results.as_ref().and_then(|c| c.name("patch")),
-        ) {
-            (Some(major), Some(minor), Some(patch)) => Revision::Semver {
-                major: SemverComponent::Fixed(major.as_str().parse::<u8>()?),
-                minor: SemverComponent::Fixed(minor.as_str().parse::<u8>()?),
-                patch: SemverComponent::Fixed(patch.as_str().parse::<u8>()?),
-            },
-            (Some(major), Some(minor), _) => Revision::Semver {
-                major: SemverComponent::Fixed(major.as_str().parse::<u8>()?),
-                minor: SemverComponent::Fixed(minor.as_str().parse::<u8>()?),
-                patch: SemverComponent::Wildcard,
-            },
-            (Some(major), _, _) => Revision::Semver {
-                major: SemverComponent::Fixed(major.as_str().parse::<u8>()?),
-                minor: SemverComponent::Wildcard,
-                patch: SemverComponent::Wildcard,
-            },
-            _ => todo!(),
-        },
-    )
 }
 
 #[derive(new, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -629,7 +559,10 @@ impl Ord for LockedDependency {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn load_lock_file() {
@@ -672,14 +605,14 @@ mod tests {
     #[test]
     fn load_valid_file_one_dep() {
         let str = r#"
-name = "test_file"
-description = "this is a description"
-proto_out_dir= "./path/to/proto_out"
-[dependency1]
-  protocol = "https"
-  url = "github.com/org/repo"
-  revision = "1.0.0"
-"#;
+            name = "test_file"
+            description = "this is a description"
+            proto_out_dir= "./path/to/proto_out"
+            [dependency1]
+                protocol = "https"
+                url = "github.com/org/repo"
+                revision = "1.0.0"
+        "#;
         let expected = Descriptor {
             name: "test_file".to_string(),
             description: Some("this is a description".to_string()),
@@ -693,7 +626,7 @@ proto_out_dir= "./path/to/proto_out"
                     protocol: Protocol::Https,
                     branch: None,
                 },
-                revision: Revision::Arbitrary {
+                revision: Revision::Fixed {
                     revision: "1.0.0".to_string(),
                 },
                 rules: Default::default(),
@@ -703,19 +636,15 @@ proto_out_dir= "./path/to/proto_out"
     }
 
     #[test]
-    fn load_valid_file_one_dep_with_rules() {
+    fn load_valid_file_no_revision() {
         let str = r#"
-name = "test_file"
-description = "this is a description"
-proto_out_dir= "./path/to/proto_out"
-[dependency1]
-  protocol = "https"
-  url = "github.com/org/repo"
-  revision = "1.0.0"
-  prune = true
-  content_roots = ["src"]
-  allow_policies = ["/foo/proto/file.proto", "/foo/other/*", "*/some/path/*"]
-"#;
+            name = "test_file"
+            description = "this is a description"
+            proto_out_dir= "./path/to/proto_out"
+            [dependency1]
+                protocol = "https"
+                url = "github.com/org/repo"
+        "#;
         let expected = Descriptor {
             name: "test_file".to_string(),
             description: Some("this is a description".to_string()),
@@ -729,7 +658,42 @@ proto_out_dir= "./path/to/proto_out"
                     protocol: Protocol::Https,
                     branch: None,
                 },
-                revision: Revision::Arbitrary {
+                revision: Revision::Arbitrary,
+                rules: Default::default(),
+            }],
+        };
+        assert_eq!(Descriptor::from_toml_str(str).unwrap(), expected);
+        assert_eq!(expected.into_toml(), toml::Value::from_str(str).unwrap())
+    }
+
+    #[test]
+    fn load_valid_file_one_dep_with_rules() {
+        let str = r#"
+            name = "test_file"
+            description = "this is a description"
+            proto_out_dir= "./path/to/proto_out"
+            [dependency1]
+                protocol = "https"
+                url = "github.com/org/repo"
+                revision = "1.0.0"
+                prune = true
+                content_roots = ["src"]
+                allow_policies = ["/foo/proto/file.proto", "/foo/other/*", "*/some/path/*"]
+        "#;
+        let expected = Descriptor {
+            name: "test_file".to_string(),
+            description: Some("this is a description".to_string()),
+            proto_out_dir: Some("./path/to/proto_out".to_string()),
+            dependencies: vec![Dependency {
+                name: DependencyName::new("dependency1".to_string()),
+                coordinate: Coordinate {
+                    forge: "github.com".to_string(),
+                    organization: "org".to_string(),
+                    repository: "repo".to_string(),
+                    protocol: Protocol::Https,
+                    branch: None,
+                },
+                revision: Revision::Fixed {
                     revision: "1.0.0".to_string(),
                 },
                 rules: Rules {
@@ -752,39 +716,39 @@ proto_out_dir= "./path/to/proto_out"
     #[should_panic]
     fn load_invalid_file_invalid_rule() {
         let str = r#"
-name = "test_file"
-description = "this is a description"
-proto_out_dir= "./path/to/proto_out"
-[dependency1]
-  protocol = "https"
-  url = "github.com/org/repo"
-  revision = "1.0.0"
-  prune = true
-  content_roots = ["src"]
-  allow_policies = ["/foo/proto/file.java"]
-"#;
+        name = "test_file"
+        description = "this is a description"
+        proto_out_dir= "./path/to/proto_out"
+        [dependency1]
+            protocol = "https"
+            url = "github.com/org/repo"
+            revision = "1.0.0"
+            prune = true
+            content_roots = ["src"]
+            allow_policies = ["/foo/proto/file.java"]
+        "#;
         Descriptor::from_toml_str(str).unwrap();
     }
 
     #[test]
     fn load_valid_file_multiple_dep() {
         let str = r#"
-name = "test_file"
-proto_out_dir= "./path/to/proto_out"
+            name = "test_file"
+            proto_out_dir= "./path/to/proto_out"
 
-[dependency1]
-  protocol = "https"
-  url = "github.com/org/repo"
-  revision = "1.0.0"
-[dependency2]
-  protocol = "https"
-  url = "github.com/org/repo"
-  revision = "2.0.0"
-[dependency3]
-  protocol = "https"
-  url = "github.com/org/repo"
-  revision = "3.0.0"
-"#;
+            [dependency1]
+                protocol = "https"
+                url = "github.com/org/repo"
+                revision = "1.0.0"
+            [dependency2]
+                protocol = "https"
+                url = "github.com/org/repo"
+                revision = "2.0.0"
+            [dependency3]
+                protocol = "https"
+                url = "github.com/org/repo"
+                revision = "3.0.0"  
+        "#;
         let expected = Descriptor {
             name: "test_file".to_string(),
             description: None,
@@ -799,7 +763,7 @@ proto_out_dir= "./path/to/proto_out"
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Arbitrary {
+                    revision: Revision::Fixed {
                         revision: "1.0.0".to_string(),
                     },
                     rules: Default::default(),
@@ -813,7 +777,7 @@ proto_out_dir= "./path/to/proto_out"
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Arbitrary {
+                    revision: Revision::Fixed {
                         revision: "2.0.0".to_string(),
                     },
                     rules: Default::default(),
@@ -827,7 +791,7 @@ proto_out_dir= "./path/to/proto_out"
                         protocol: Protocol::Https,
                         branch: None,
                     },
-                    revision: Revision::Arbitrary {
+                    revision: Revision::Fixed {
                         revision: "3.0.0".to_string(),
                     },
                     rules: Default::default(),
@@ -847,9 +811,9 @@ proto_out_dir= "./path/to/proto_out"
     #[test]
     fn load_file_no_deps() {
         let str = r#"
-    name = "test_file"
-    proto_out_dir = "./path/to/proto_out"
-    "#;
+            name = "test_file"
+            proto_out_dir = "./path/to/proto_out"
+        "#;
         let expected = Descriptor {
             name: "test_file".to_string(),
             description: None,
@@ -857,31 +821,32 @@ proto_out_dir= "./path/to/proto_out"
             dependencies: vec![],
         };
         assert_eq!(Descriptor::from_toml_str(str).unwrap(), expected);
+        assert_eq!(expected.into_toml(), toml::Value::from_str(str).unwrap())
     }
 
     #[test]
     fn load_invalid_protocol() {
         let str = r#"
-name = "test_file"
-proto_out_dir = "./path/to/proto_out"
-[dependency1]
-  protocol = "ftp"
-  url = "github.com/org/repo"
-  revision = "1.0.0"
-"#;
+            name = "test_file"
+            proto_out_dir = "./path/to/proto_out"
+            [dependency1]
+                protocol = "ftp"
+                url = "github.com/org/repo"
+                revision = "1.0.0"
+        "#;
         assert!(Descriptor::from_toml_str(str).is_err());
     }
 
     #[test]
     fn load_invalid_url() {
         let str = r#"
-name = "test_file"
-proto_out_dir = "./path/to/proto_out"
-[dependency1]
-  protocol = "ftp"
-  url = "github.com/org"
-  revision = "1.0.0"
-"#;
+            name = "test_file"
+            proto_out_dir = "./path/to/proto_out"
+            [dependency1]
+                protocol = "ftp"
+                url = "github.com/org"
+                revision = "1.0.0"
+        "#;
         assert!(Descriptor::from_toml_str(str).is_err());
     }
 

--- a/src/proto_repository.rs
+++ b/src/proto_repository.rs
@@ -88,7 +88,7 @@ impl ProtoRepository for ProtoGitRepository {
         revision: &Revision,
     ) -> Result<Descriptor, ProtoRepoError> {
         let rendered_revision = match revision {
-            Revision::Fixed { revision } => revision,
+            Revision::Pinned { revision } => revision,
             Revision::Arbitrary => todo!(),
         }
         .to_owned();
@@ -211,13 +211,13 @@ impl ProtoRepository for ProtoGitRepository {
     ) -> Result<String, ProtoRepoError> {
         let oid = match (branch, revision) {
             (None, Revision::Arbitrary) => self.commit_hash_for_obj_str("HEAD")?,
-            (None, Revision::Fixed { revision }) => self.commit_hash_for_obj_str(revision)?,
+            (None, Revision::Pinned { revision }) => self.commit_hash_for_obj_str(revision)?,
             (Some(branch), Revision::Arbitrary) => self
                 .commit_hash_for_obj_str(&format!("origin/{branch}"))
                 .map_err(|_| ProtoRepoError::BranchNotFound {
                     branch: branch.to_owned(),
                 })?,
-            (Some(branch), Revision::Fixed { revision }) => {
+            (Some(branch), Revision::Pinned { revision }) => {
                 let branch_commit = self
                     .commit_hash_for_obj_str(&format!("origin/{branch}"))
                     .map_err(|_| ProtoRepoError::BranchNotFound {


### PR DESCRIPTION
1. Make `revision` optional.
2. Remove unused code for semantic versions support.
3. If both `branch` and `revision` are specified, verify that the `revision` belongs to a branch. Previously, `revision` was completely ignored, which was was very counter-intuitive.

Closes #32.