### PR TITLE
Use gtar instead of bsdtar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,11 @@ jobs:
         run: |
           cargo build --release
       
+      # We use gtar to make sure compressed files are not detected as sparse
       - name: Package
         run: |
           mv target/release bin/
-          tar -czvf protofetch_darwin_amd64.tar.gz bin/protofetch
+          gtar -czvf protofetch_darwin_amd64.tar.gz bin/protofetch
 
       - name: Upload
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
For bsdtar <3.6.0 there seems to be no way to disable sparse files detection, macOS binary contains a region full of zeroes big enough to be detected as a hole, and node-tar cannot unpack such archives.