### PR TITLE
Use tracing library for error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
 name = "jobserver"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,6 +408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +454,16 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-traits"
@@ -484,10 +509,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pkg-config"
@@ -559,7 +596,6 @@ dependencies = [
  "env_logger",
  "git2",
  "home",
- "log",
  "mockall",
  "pretty_assertions",
  "project-root",
@@ -568,6 +604,8 @@ dependencies = [
  "strum",
  "thiserror",
  "toml",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -587,8 +625,23 @@ checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -617,6 +670,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "serde"
 version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +696,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,6 +714,21 @@ checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "strsim"
@@ -731,6 +816,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,6 +875,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +986,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,13 @@ derive-new = "0.5.9"
 env_logger = "0.10.0"
 git2 = "0.17.2"
 home = "0.5.5"
-log = "0.4.18"
 regex = "1.8.4"
 serde = { version = "1.0.163", features = ["derive"] }
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.40"
 toml = "0.7.4"
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter", "fmt", "json"] }
 
 [dev-dependencies]
 mockall = "0.11.4"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This can be changed, but it is heavily discouraged.
 | Field          | Type     | Required  |                                     Description                                     |                                           Example |
 |----------------|:---------|:----------|:-----------------------------------------------------------------------------------:|--------------------------------------------------:|
 | url            | String   | mandatory |               the address of the repo to checkout protobuf files from               |              "github.com/coralogix/cx-api-users/" |
-| revision       | String   | mandatory | the revision to checkout from, this can either be a tagged version or a commit hash |                                              v0.2 |
+| revision       | String   | Optional | the revision to checkout from, this can either be a tagged version or a commit hash |                                              v0.2 |
 | branch         | Boolean  | Optional  |  branch can be used to override revision for testing purposes, fetches last commit  |                                        feature/v2 |
 | protocol       | String   | mandatory |                            protocol to use: [ssh, https]                            |                                               ssh |
 | allow_policies | [String] | Optional  |                                 Allow policy rules.                                 | "/prefix/*", "*/subpath/*", "/path/to/file.proto" |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.70.0"
+channel = "1.71.1"

--- a/src/api/builder.rs
+++ b/src/api/builder.rs
@@ -121,6 +121,7 @@ impl ProtofetchBuilder {
 fn default_cache_directory() -> PathBuf {
     let mut cache_directory =
         home_dir().expect("Could not find home dir. Please define $HOME env variable.");
-    cache_directory.push(".protofetch/cache");
+    cache_directory.push(".protofetch");
+    cache_directory.push("cache");
     cache_directory
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use git2::Config;
 use git2::{build::RepoBuilder, Cred, CredentialType, FetchOptions, RemoteCallbacks, Repository};
 use thiserror::Error;
-use tracing::{trace};
+use tracing::trace;
 
 use crate::{
     cli::HttpGitAuth, model::protofetch::Coordinate, proto_repository::ProtoGitRepository,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,8 +2,8 @@ use std::path::{Path, PathBuf};
 
 use git2::Config;
 use git2::{build::RepoBuilder, Cred, CredentialType, FetchOptions, RemoteCallbacks, Repository};
-use log::trace;
 use thiserror::Error;
+use tracing::{trace};
 
 use crate::{
     cli::HttpGitAuth, model::protofetch::Coordinate, proto_repository::ProtoGitRepository,
@@ -22,6 +22,15 @@ pub struct ProtofetchGitCache {
     pub location: PathBuf,
     git_config: Config,
     git_auth: Option<HttpGitAuth>,
+}
+
+impl std::fmt::Debug for ProtofetchGitCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProtofetchGitCache")
+            .field("location", &self.location)
+            .field("git_auth", &self.git_auth)
+            .finish()
+    }
 }
 
 #[derive(Error, Debug)]

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -1,4 +1,4 @@
-use log::info;
+use tracing::{debug, info, instrument};
 
 use crate::{
     cache::ProtofetchGitCache,
@@ -17,6 +17,7 @@ use std::{
 const DEFAULT_OUTPUT_DIRECTORY_NAME: &str = "proto_src";
 
 /// Handler to fetch command
+#[instrument]
 pub fn do_fetch(
     force_lock: bool,
     cache: &ProtofetchGitCache,
@@ -56,7 +57,7 @@ pub fn do_lock(
     module_file_name: &Path,
     lock_file_name: &Path,
 ) -> Result<LockFile, Box<dyn Error>> {
-    log::debug!("Generating lockfile...");
+    debug!("Generating lockfile...");
     let root = root.canonicalize()?;
     let module_file_path = root.join(module_file_name);
     let lock_file_path = root.join(lock_file_name);
@@ -69,11 +70,11 @@ pub fn do_lock(
 
     let lockfile = fetch::lock(&module_descriptor, cache)?;
 
-    log::debug!("Generated lockfile: {:?}", lockfile);
+    debug!("Generated lockfile: {:?}", lockfile);
     let value_toml = toml::Value::try_from(&lockfile)?;
     std::fs::write(&lock_file_path, toml::to_string_pretty(&value_toml)?)?;
 
-    log::info!("Wrote lockfile to {}", lock_file_path.display());
+    info!("Wrote lockfile to {}", lock_file_path.to_string_lossy());
 
     Ok(lockfile)
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -12,9 +12,9 @@ use crate::{
     },
     proto_repository::ProtoRepository,
 };
-use log::{debug, error, info};
 use std::iter::FromIterator;
 use thiserror::Error;
+use tracing::{debug, error, info, warn};
 
 #[derive(Error, Debug)]
 pub enum FetchError {
@@ -61,7 +61,7 @@ pub fn lock<Cache: RepositoryCache>(
         parent: Option<&DependencyName>,
     ) -> Result<(), FetchError> {
         for dependency in dependencies {
-            log::info!("Resolving {:?}", dependency.coordinate);
+            tracing::info!("Resolving {:?}", dependency.coordinate);
 
             dep_map
                 .entry(dependency.name.clone())
@@ -198,11 +198,9 @@ fn resolve_conflicts(
                                 revision: result_revision,
                             } => {
                                 if result_revision != revision {
-                                    log::warn!(
+                                    warn!(
                                         "discarded revision {} in favor of {} for {}",
-                                        revision,
-                                        result_revision,
-                                        name.value
+                                        revision, result_revision, name.value
                                     )
                                 }
                             }
@@ -215,11 +213,9 @@ fn resolve_conflicts(
                         match &result.branch {
                             Some(result_branch) => {
                                 if result_branch != branch {
-                                    log::warn!(
+                                    warn!(
                                         "discarded branch {} in favor of {} for {}",
-                                        branch,
-                                        result_branch,
-                                        name.value
+                                        branch, result_branch, name.value
                                     )
                                 }
                             }
@@ -238,7 +234,7 @@ fn locked_dependencies(
 ) -> Result<Vec<LockedDependency>, FetchError> {
     let mut locked_deps = Vec::new();
     for (name, (rules, coordinate, repository, specification, specifications, deps)) in dep_map {
-        log::info!("Locking {:?} at {:?}", coordinate, specification);
+        info!("Locking {:?} at {:?}", coordinate, specification);
 
         let commit_hash = repository.resolve_commit_hash(&specification)?;
         let locked_dep = LockedDependency {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
 use std::{env, error::Error};
 
 use clap::Parser;
-use env_logger::Target;
 
-use log::warn;
+use tracing::warn;
 use protofetch::Protofetch;
+
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 
 /// Dependency management tool for Protocol Buffers files.
 #[derive(Debug, Parser)]
@@ -69,12 +72,35 @@ pub enum Command {
 }
 
 fn main() {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
-        .target(Target::Stdout)
-        .init();
+    // -- NOTE --------------------------------------------------------------------------------------
+    // The filtering methods on a stack of Layers are evaluated in a top-down order, starting
+    // with the outermost Layer and ending with the wrapped Subscriber. If any layer returns
+    // false from its enabled method, or Interest::never() from its register_callsite method,
+    // filter evaluation will short-circuit and the span or event will be disabled.
+    //
+    // https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/index.html#global-filtering
+    // ----------------------------------------------------------------------------------------------
+    let filter = tracing_subscriber::EnvFilter::builder()
+        .with_env_var("RUST_LOG")
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    // Initialize stdout output;
+    let stdout_layer = tracing_subscriber::fmt::layer()
+        .with_line_number(true)
+        .with_file(true)
+        .with_thread_ids(false)
+        .with_target(true)
+        .with_ansi(true);
+
+    tracing_subscriber::registry()
+        .with(stdout_layer)
+        .with(filter)
+        .try_init()
+        .unwrap();
 
     if let Err(e) = run() {
-        log::error!("{}", e)
+        tracing::error!("{}", e)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,8 @@ use std::{env, error::Error};
 
 use clap::Parser;
 
-use tracing::warn;
 use protofetch::Protofetch;
+use tracing::warn;
 
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;

--- a/src/model/protodep.rs
+++ b/src/model/protodep.rs
@@ -5,10 +5,10 @@ use crate::model::{
     },
     ParseError,
 };
-use log::{debug, error};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path, str::FromStr};
 use toml::Value;
+use tracing::{debug, error};
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -11,9 +11,9 @@ use std::{
 use strum::EnumString;
 
 use crate::model::ParseError;
-use log::{debug, error};
 use std::{collections::BTreeSet, hash::Hash};
 use toml::{map::Map, Value};
+use tracing::{debug, error};
 
 #[derive(PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Ord, PartialOrd)]
 pub struct Coordinate {
@@ -731,7 +731,7 @@ mod tests {
             [dependency3]
                 protocol = "https"
                 url = "github.com/org/repo"
-                revision = "3.0.0"  
+                revision = "3.0.0"
         "#;
         let expected = Descriptor {
             name: "test_file".to_string(),

--- a/src/proto_repository.rs
+++ b/src/proto_repository.rs
@@ -2,10 +2,10 @@ use std::{
     path::{Path, PathBuf},
     str::Utf8Error,
 };
+use tracing::{debug, error};
 
 use crate::model::protofetch::{DependencyName, Descriptor, Revision, RevisionSpecification};
 use git2::{Oid, Repository, ResetType};
-use log::debug;
 use thiserror::Error;
 
 #[cfg(test)]
@@ -93,7 +93,9 @@ impl ProtoRepository for ProtoGitRepository {
 
         match result {
             Err(e) if e.code() == git2::ErrorCode::NotFound => {
-                log::debug!("Couldn't find protofetch.toml, assuming module has no dependencies");
+                tracing::debug!(
+                    "Couldn't find protofetch.toml, assuming module has no dependencies"
+                );
                 Ok(Descriptor {
                     name: dep_name.value.clone(),
                     description: None,
@@ -168,7 +170,7 @@ impl ProtoRepository for ProtoGitRepository {
                         wanted_path: worktree_path.to_str().unwrap_or("").to_string(),
                     });
                 } else {
-                    log::info!(
+                    tracing::info!(
                         "Module[{}] Found existing worktree for dep {:?} at {}.",
                         module_name,
                         dep_name,
@@ -177,7 +179,7 @@ impl ProtoRepository for ProtoGitRepository {
                 }
             }
             Err(_) => {
-                log::info!(
+                tracing::info!(
                     "Module[{}] Creating new worktree for dep {:?} at {}.",
                     module_name,
                     dep_name,


### PR DESCRIPTION
* Use the `tracing` crate instead of `log` for rendering error messages
* Bump the rust toolchain version to 1.71