### PR TITLE
Make the way the default cache directory is generated consistent on Windows

### DIFF
--- a/src/api/builder.rs
+++ b/src/api/builder.rs
@@ -121,6 +121,7 @@ impl ProtofetchBuilder {
 fn default_cache_directory() -> PathBuf {
     let mut cache_directory =
         home_dir().expect("Could not find home dir. Please define $HOME env variable.");
-    cache_directory.push(".protofetch/cache");
+    cache_directory.push(".protofetch");
+    cache_directory.push("cache");
     cache_directory
 }


### PR DESCRIPTION
This change modifies the `.protofetch/cache` string literal that is pushed onto a `PathBuf` to instead be two separate calls to `.push`, so that protofetch generates this path consistently on Windows and Unix.