### PR TITLE
Exit with a nonzero error code on error

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,8 @@ fn main() {
         .init();
 
     if let Err(e) = run() {
-        log::error!("{}", e)
+        log::error!("{}", e);
+        std::process::exit(1);
     }
 }
 


### PR DESCRIPTION
If the `main` method of `protofetch` would log an error before exiting, also exit with a non-zero error code. 