### PR TITLE
Fix windows artifact name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,13 @@ jobs:
       - name: Package
         run: |
           mv target/release bin/
-          tar -czvf protofetch_win64.tar.gz bin/protofetch.exe
+          tar -czvf protofetch_windows_amd64.tar.gz bin/protofetch.exe
 
       - name: Upload
         uses: actions/upload-artifact@v3
         with:
           name: packages
-          path: protofetch_win64.tar.gz
+          path: protofetch_windows_amd64.tar.gz
 
   release:
     runs-on: ubuntu-latest
@@ -177,4 +177,4 @@ jobs:
             protofetch_aarch64-unknown-linux-musl.tar.gz
             protofetch_x86_64-unknown-linux-musl.tar.gz
             protofetch_darwin_amd64.tar.gz
-            protofetch_win64.tar.gz
+            protofetch_windows_amd64.tar.gz


### PR DESCRIPTION
Both the [npm package](https://github.com/coralogix/protofetch/blob/5cd349af19f5e2f29aecde0bba0c087d47c903e9/.github/npm/getBinary.js#L9) and [sbt-protodep](https://github.com/coralogix/sbt-protodep/blob/9a2132d2c1ccd6f3c9a939ba03f3ddd757031ee1/src/main/scala/com/coralogix/sbtprotodep/backends/BackendBinary.scala#L175) use `protofetch_windows_amd64.tar.gz`.