### PR TITLE
Allow protocol to be specified in the URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "home",
  "log",
  "mockall",
+ "once_cell",
  "pretty_assertions",
  "project-root",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ env_logger = "0.10.0"
 git2 = "0.17.2"
 home = "0.5.5"
 log = "0.4.18"
+once_cell = "1.18.0"
 regex = "1.8.4"
 serde = { version = "1.0.163", features = ["derive"] }
 strum = { version = "0.24.1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ This can be changed, but it is heavily discouraged.
 
 | Field          | Type     | Required  |                                     Description                                     |                                           Example |
 |----------------|:---------|:----------|:-----------------------------------------------------------------------------------:|--------------------------------------------------:|
-| url            | String   | mandatory |               the address of the repo to checkout protobuf files from               |              "github.com/coralogix/cx-api-users/" |
-| revision       | String   | Optional | the revision to checkout from, this can either be a tagged version or a commit hash |                                              v0.2 |
-| branch         | Boolean  | Optional  |  branch can be used to override revision for testing purposes, fetches last commit  |                                        feature/v2 |
-| protocol       | String   | mandatory |                            protocol to use: [ssh, https]                            |                                               ssh |
+| url            | String   | mandatory |               The address of the repo to checkout protobuf files from.              |              "github.com/coralogix/cx-api-users/" |
+| revision       | String   | Optional | The revision to checkout from. This can either be a tagged version or a commit hash. |                                              v0.2 |
+| branch         | Boolean  | Optional  | Branch can be used to override revision for testing purposes, fetches last commit. |                                        feature/v2 |
+| protocol       | String   | Optional  | Protocol to use: [ssh, https] . Unnecessary if the protocol is specified in the URL (e.g. `https://example.com/repo/path`).|   ssh |
 | allow_policies | [String] | Optional  |                                 Allow policy rules.                                 | "/prefix/*", "*/subpath/*", "/path/to/file.proto" |
 | deny_policies  | [String] | Optional  |                                 Deny policy rules.                                  | "/prefix/*", "*/subpath/*", "/path/to/file.proto" |
 | prune          | bool     | Optional  |                   Whether to prune unneded transitive proto files                   |                                       true /false |
@@ -106,8 +106,7 @@ revision = "5.2.0"
 branch = "feature/v2"
 
 [another-name]
-protocol = "ssh"
-url = "github.com/org/dep3"
+url = "ssh://github.com/org/dep3"
 revision = "a16f097eab6e64f2b711fd4b977e610791376223"
 transitive = true
 ```

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -297,12 +297,8 @@ mod tests {
             dependencies: vec![
                 Dependency {
                     name: DependencyName::new("dependency1".to_string()),
-                    coordinate: Coordinate {
-                        forge: "github.com".to_string(),
-                        organization: "org".to_string(),
-                        repository: "repo".to_string(),
-                        protocol: Protocol::Https,
-                    },
+                    coordinate: Coordinate::from_url("github.com/org/repo", Protocol::Https)
+                        .unwrap(),
                     specification: RevisionSpecification {
                         revision: Revision::Pinned {
                             revision: "1.0.0".to_string(),
@@ -313,12 +309,8 @@ mod tests {
                 },
                 Dependency {
                     name: DependencyName::new("dependency2".to_string()),
-                    coordinate: Coordinate {
-                        forge: "github.com".to_string(),
-                        organization: "org".to_string(),
-                        repository: "repo".to_string(),
-                        protocol: Protocol::Https,
-                    },
+                    coordinate: Coordinate::from_url("github.com/org/repo", Protocol::Https)
+                        .unwrap(),
                     specification: RevisionSpecification {
                         revision: Revision::Pinned {
                             revision: "2.0.0".to_string(),
@@ -349,12 +341,8 @@ mod tests {
                 },
                 Dependency {
                     name: DependencyName::new("dependency3".to_string()),
-                    coordinate: Coordinate {
-                        forge: "github.com".to_string(),
-                        organization: "org".to_string(),
-                        repository: "repo".to_string(),
-                        protocol: Protocol::Https,
-                    },
+                    coordinate: Coordinate::from_url("github.com/org/repo", Protocol::Https)
+                        .unwrap(),
                     specification: RevisionSpecification {
                         revision: Revision::Pinned {
                             revision: "3.0.0".to_string(),

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -285,9 +285,7 @@ mod tests {
     #[test]
     fn lock_from_descriptor_always_the_same() {
         use crate::{
-            cache::MockRepositoryCache,
-            model::protofetch::{Protocol, *},
-            proto_repository::MockProtoRepository,
+            cache::MockRepositoryCache, model::protofetch::*, proto_repository::MockProtoRepository,
         };
         let mut mock_repo_cache = MockRepositoryCache::new();
         let desc = Descriptor {
@@ -297,11 +295,7 @@ mod tests {
             dependencies: vec![
                 Dependency {
                     name: DependencyName::new("dependency1".to_string()),
-                    coordinate: Coordinate::from_url_and_proto(
-                        "github.com/org/repo",
-                        Protocol::Https,
-                    )
-                    .unwrap(),
+                    coordinate: Coordinate::from_url("https://github.com/org/repo").unwrap(),
                     specification: RevisionSpecification {
                         revision: Revision::Pinned {
                             revision: "1.0.0".to_string(),
@@ -312,11 +306,7 @@ mod tests {
                 },
                 Dependency {
                     name: DependencyName::new("dependency2".to_string()),
-                    coordinate: Coordinate::from_url_and_proto(
-                        "github.com/org/repo",
-                        Protocol::Https,
-                    )
-                    .unwrap(),
+                    coordinate: Coordinate::from_url("https://github.com/org/repo").unwrap(),
                     specification: RevisionSpecification {
                         revision: Revision::Pinned {
                             revision: "2.0.0".to_string(),
@@ -347,11 +337,7 @@ mod tests {
                 },
                 Dependency {
                     name: DependencyName::new("dependency3".to_string()),
-                    coordinate: Coordinate::from_url_and_proto(
-                        "github.com/org/repo",
-                        Protocol::Https,
-                    )
-                    .unwrap(),
+                    coordinate: Coordinate::from_url("https://github.com/org/repo").unwrap(),
                     specification: RevisionSpecification {
                         revision: Revision::Pinned {
                             revision: "3.0.0".to_string(),

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -297,8 +297,11 @@ mod tests {
             dependencies: vec![
                 Dependency {
                     name: DependencyName::new("dependency1".to_string()),
-                    coordinate: Coordinate::from_url("github.com/org/repo", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "github.com/org/repo",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specification: RevisionSpecification {
                         revision: Revision::Pinned {
                             revision: "1.0.0".to_string(),
@@ -309,8 +312,11 @@ mod tests {
                 },
                 Dependency {
                     name: DependencyName::new("dependency2".to_string()),
-                    coordinate: Coordinate::from_url("github.com/org/repo", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "github.com/org/repo",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specification: RevisionSpecification {
                         revision: Revision::Pinned {
                             revision: "2.0.0".to_string(),
@@ -341,8 +347,11 @@ mod tests {
                 },
                 Dependency {
                     name: DependencyName::new("dependency3".to_string()),
-                    coordinate: Coordinate::from_url("github.com/org/repo", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "github.com/org/repo",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specification: RevisionSpecification {
                         revision: Revision::Pinned {
                             revision: "3.0.0".to_string(),
@@ -389,7 +398,8 @@ mod tests {
 
     #[test]
     fn resolve_conflict_picks_latest_revision_and_branch() {
-        let coord1 = Coordinate::from_url("example.com/org/dep1", Protocol::Https).unwrap();
+        let coord1 =
+            Coordinate::from_url_and_proto("example.com/org/dep1", Protocol::Https).unwrap();
         let name = DependencyName::new("foo".to_string());
         let input = BTreeMap::from_iter(iter::once((
             name.clone(),
@@ -433,9 +443,12 @@ mod tests {
 
     #[test]
     fn resolve_conflict_picks_first_coordinate() {
-        let coord1 = Coordinate::from_url("example.com/org/dep1", Protocol::Https).unwrap();
-        let coord2 = Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap();
-        let coord3 = Coordinate::from_url("example.com/org/dep3", Protocol::Https).unwrap();
+        let coord1 =
+            Coordinate::from_url_and_proto("example.com/org/dep1", Protocol::Https).unwrap();
+        let coord2 =
+            Coordinate::from_url_and_proto("example.com/org/dep2", Protocol::Https).unwrap();
+        let coord3 =
+            Coordinate::from_url_and_proto("example.com/org/dep3", Protocol::Https).unwrap();
         let name = DependencyName::new("foo".to_string());
         let main = RevisionSpecification {
             revision: Revision::Arbitrary,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -20,4 +20,6 @@ pub enum ParseError {
     ParsePolicyRuleError(String),
     #[error("Missing url component `{0}` in string `{1}`")]
     MissingUrlComponent(String, String),
+    #[error("Invalid url component `{0}` in string `{1}`")]
+    InvalidUrlComponent(String, String),
 }

--- a/src/model/protodep.rs
+++ b/src/model/protodep.rs
@@ -71,7 +71,7 @@ impl ProtodepDescriptor {
     pub fn into_proto_fetch(self) -> Result<Descriptor, ParseError> {
         fn convert_dependency(d: Dependency) -> Result<ProtofetchDependency, ParseError> {
             let protocol: Protocol = Protocol::from_str(&d.protocol)?;
-            let coordinate = Coordinate::from_url(d.target.as_str(), protocol)?;
+            let coordinate = Coordinate::from_url_and_proto(d.target.as_str(), protocol)?;
             let specification = RevisionSpecification {
                 revision: Revision::pinned(d.revision),
                 branch: d.branch,

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -58,11 +58,15 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep1",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: vec![LockedCoordinateRevisionSpecification {
                         coordinate: Some(
-                            Coordinate::from_url("example.com/org/dep1", Protocol::Https).unwrap(),
+                            Coordinate::from_url_and_proto("example.com/org/dep1", Protocol::Https)
+                                .unwrap(),
                         ),
                         specification: RevisionSpecification {
                             revision: Revision::pinned("1.0.0"),
@@ -84,8 +88,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep2",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -24,7 +24,7 @@ pub struct Coordinate {
 }
 
 impl Coordinate {
-    pub fn from_url(url: &str, protocol: Protocol) -> Result<Coordinate, ParseError> {
+    pub fn from_url_and_proto(url: &str, protocol: Protocol) -> Result<Coordinate, ParseError> {
         let re: Regex =
             Regex::new(r"^(?P<forge>[^/]+)/(?P<organization>[^/]+)/(?P<repository>[^/]+)/?$")
                 .unwrap();
@@ -510,7 +510,7 @@ fn parse_dependency(name: String, value: &toml::Value) -> Result<Dependency, Par
         .get("url")
         .ok_or_else(|| ParseError::MissingKey("url".to_string()))
         .and_then(|x| x.clone().try_into::<String>().map_err(|e| e.into()))
-        .and_then(|url| Coordinate::from_url(&url, protocol))?;
+        .and_then(|url| Coordinate::from_url_and_proto(&url, protocol))?;
 
     let revision = match value.get("revision") {
         Some(revision) => parse_revision(revision)?,
@@ -838,7 +838,7 @@ mod tests {
     fn build_coordinate() {
         let str = "github.com/coralogix/cx-api-users";
         assert_eq!(
-            Coordinate::from_url(str, Protocol::Https).unwrap(),
+            Coordinate::from_url_and_proto(str, Protocol::Https).unwrap(),
             Coordinate {
                 forge: "github.com".to_owned(),
                 organization: "coralogix".to_owned(),
@@ -852,7 +852,7 @@ mod tests {
     fn build_coordinate_slash() {
         let str = "github.com/coralogix/cx-api-users/";
         assert_eq!(
-            Coordinate::from_url(str, Protocol::Https).unwrap(),
+            Coordinate::from_url_and_proto(str, Protocol::Https).unwrap(),
             Coordinate {
                 forge: "github.com".to_owned(),
                 organization: "coralogix".to_owned(),

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -20,7 +20,7 @@ pub struct Coordinate {
     pub forge: String,
     pub organization: String,
     pub repository: String,
-    pub protocol: Protocol,
+    protocol: Protocol,
 }
 
 impl Coordinate {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -448,7 +448,8 @@ mod tests {
         let lock_file = LockedDependency {
             name: DependencyName::new("dep3".to_string()),
             commit_hash: "hash3".to_string(),
-            coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https).unwrap(),
+            coordinate: Coordinate::from_url_and_proto("example.com/org/dep3", Protocol::Https)
+                .unwrap(),
             specifications: Vec::default(),
             dependencies: BTreeSet::new(),
             rules: Rules::new(
@@ -487,8 +488,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep1",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::new(
@@ -505,8 +509,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep2",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -565,8 +572,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep1",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::from([
                         DependencyName::new("dep2".to_string()),
@@ -577,8 +587,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep2",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -586,8 +599,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep3".to_string()),
                     commit_hash: "hash3".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep3",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -595,8 +611,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep4".to_string()),
                     commit_hash: "hash4".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep4", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep4",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::new(
@@ -627,8 +646,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep1",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -636,8 +658,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep2",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -645,8 +670,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep3".to_string()),
                     commit_hash: "hash3".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep3",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -667,8 +695,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep1",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::default(),
@@ -676,8 +707,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep2",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -685,8 +719,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep3".to_string()),
                     commit_hash: "hash3".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep3",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::from([
                         DependencyName::new("dep2".to_string()),
@@ -701,8 +738,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep4".to_string()),
                     commit_hash: "hash4".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep4", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep4",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -710,8 +750,11 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep5".to_string()),
                     commit_hash: "hash5".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep5", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url_and_proto(
+                        "example.com/org/dep5",
+                        Protocol::Https,
+                    )
+                    .unwrap(),
                     specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules {
@@ -753,7 +796,8 @@ transitive = false
             dependencies: vec![LockedDependency {
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
-                coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
+                coordinate: Coordinate::from_url_and_proto("example.com/org/dep2", Protocol::Https)
+                    .unwrap(),
                 specifications: Vec::default(),
                 dependencies: BTreeSet::new(),
                 rules: Rules::default(),
@@ -772,7 +816,8 @@ transitive = false
             dependencies: vec![LockedDependency {
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
-                coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
+                coordinate: Coordinate::from_url_and_proto("example.com/org/dep2", Protocol::Https)
+                    .unwrap(),
                 specifications: Vec::default(),
                 dependencies: BTreeSet::new(),
                 rules: Rules::default(),


### PR DESCRIPTION
This commit makes it possible to specify the repository url as a string including the protocol, e.g. `https://github.com/org/repo` or `ssh://gitlab.org/org/repo`, making the `protocol` field of the `protofetch.toml` file unnecessary.

The code in this PR will assume whatever is specified in the `protocol` field if it is present in the TOML file; if that TOML key is missing it will attempt to parse the protocol out of the url, and fail if it is not present. This is a breaking change for `protofetch.toml` files that currently omit the `protocol` field (which is allowed, despite the text of the README) and rely on its default value of "https"; but I think this is a good change nonetheless. It's easier to debug a failure with an error message than it is to debug something that is silently using a value you don't expect it to. 