### PR TITLE
Remove output dir from the lock file

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -73,6 +73,7 @@ impl Protofetch {
     pub fn clean(&self) -> Result<(), Box<dyn Error>> {
         do_clean(
             &self.root,
+            &self.module_file_name,
             &self.lock_file_name,
             self.output_directory_name.as_deref(),
         )

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -26,24 +26,28 @@ pub fn do_fetch(
     cache_dependencies_directory_name: &Path,
     output_directory_name: Option<&Path>,
 ) -> Result<(), Box<dyn Error>> {
+    let module_descriptor = load_module_descriptor(root, module_file_name)?;
+
     let lock_file_path = root.join(lock_file_name);
     let lockfile = if force_lock || !lock_file_path.exists() {
         do_lock(cache, root, module_file_name, lock_file_name)?
     } else {
         LockFile::from_file(&lock_file_path)?
     };
+
     let cache_dependencies_directory_path = cache.location.join(cache_dependencies_directory_name);
     let output_directory_name = output_directory_name
-        .or_else(|| lockfile.proto_out_dir.as_ref().map(Path::new))
+        .or_else(|| module_descriptor.proto_out_dir.as_ref().map(Path::new))
         .unwrap_or(Path::new(DEFAULT_OUTPUT_DIRECTORY_NAME));
-    let output_directory_path = root.join(output_directory_name);
     fetch::fetch_sources(cache, &lockfile, &cache_dependencies_directory_path)?;
+
     //Copy proto_out files to actual target
     proto::copy_proto_files(
-        &output_directory_path,
+        &root.join(output_directory_name),
         &cache_dependencies_directory_path,
         &lockfile,
     )?;
+
     Ok(())
 }
 
@@ -56,23 +60,16 @@ pub fn do_lock(
     module_file_name: &Path,
     lock_file_name: &Path,
 ) -> Result<LockFile, Box<dyn Error>> {
+    let module_descriptor = load_module_descriptor(root, module_file_name)?;
+
     log::debug!("Generating lockfile...");
-    let root = root.canonicalize()?;
-    let module_file_path = root.join(module_file_name);
-    let lock_file_path = root.join(lock_file_name);
-    let protodep_toml_path = root.join(Path::new("protodep.toml"));
-
-    let module_descriptor = Descriptor::from_file(module_file_path.as_path()).or_else(|_| {
-        ProtodepDescriptor::from_file(protodep_toml_path.as_path())
-            .and_then(|d| d.into_proto_fetch())
-    })?;
-
     let lockfile = fetch::lock(&module_descriptor, cache)?;
 
     log::debug!("Generated lockfile: {:?}", lockfile);
     let value_toml = toml::Value::try_from(&lockfile)?;
-    std::fs::write(&lock_file_path, toml::to_string_pretty(&value_toml)?)?;
 
+    let lock_file_path = root.join(lock_file_name);
+    std::fs::write(&lock_file_path, toml::to_string_pretty(&value_toml)?)?;
     log::info!("Wrote lockfile to {}", lock_file_path.display());
 
     Ok(lockfile)
@@ -84,8 +81,7 @@ pub fn do_init(
     name: Option<String>,
     module_file_name: &Path,
 ) -> Result<(), Box<dyn Error>> {
-    let root = root.canonicalize()?;
-    let name = build_module_name(name, &root)?;
+    let name = build_module_name(name, root)?;
     let descriptor = Descriptor::new(name, None, None, vec![]);
     let module_file_path = root.join(module_file_name);
     create_module_dir(descriptor, &module_file_path, false)
@@ -102,54 +98,52 @@ pub fn do_migrate(
     module_file_name: &Path,
     source_directory_path: &Path,
 ) -> Result<(), Box<dyn Error>> {
-    //protodep default file
-    let protodep_toml_path = source_directory_path.join("protodep.toml");
-    let protodep_lock_path = source_directory_path.join("protodep.lock");
-    let descriptor =
-        ProtodepDescriptor::from_file(&protodep_toml_path).and_then(|d| d.into_proto_fetch())?;
-    let root = Path::new(root).canonicalize()?;
-    let name = build_module_name(name, &root)?;
+    let descriptor = ProtodepDescriptor::from_file(&source_directory_path.join("protodep.toml"))
+        .and_then(|d| d.into_proto_fetch())?;
+
+    let name = build_module_name(name, root)?;
     let descriptor_with_name = Descriptor { name, ..descriptor };
-    let module_file_path = root.join(module_file_name);
-    create_module_dir(descriptor_with_name, &module_file_path, false)?;
-    std::fs::remove_file(protodep_toml_path)?;
-    std::fs::remove_file(protodep_lock_path)?;
+    create_module_dir(descriptor_with_name, &root.join(module_file_name), false)?;
+
+    std::fs::remove_file(source_directory_path.join("protodep.toml"))?;
+    std::fs::remove_file(source_directory_path.join("protodep.lock"))?;
+
     Ok(())
 }
 
 pub fn do_clean(
     root: &Path,
+    module_file_name: &Path,
     lock_file_name: &Path,
     output_directory_name: Option<&Path>,
 ) -> Result<(), Box<dyn Error>> {
+    let module_descriptor = load_module_descriptor(root, module_file_name)?;
+
     let lock_file_path = root.join(lock_file_name);
-    if lock_file_path.exists() {
-        let lockfile = LockFile::from_file(&lock_file_path)?;
-        let output_directory_name = output_directory_name
-            .or_else(|| lockfile.proto_out_dir.as_ref().map(Path::new))
-            .unwrap_or(Path::new(DEFAULT_OUTPUT_DIRECTORY_NAME));
-        let output_directory_path = root.join(output_directory_name);
-        info!(
-            "Cleaning protofetch proto_out source files folder {}.",
-            output_directory_path.display()
-        );
-        let output1 = std::fs::remove_dir_all(&output_directory_path);
-        let output2 = std::fs::remove_file(&lock_file_path);
 
-        for (output, path) in [(output1, output_directory_path), (output2, lock_file_path)] {
-            match output {
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    info!("{} is already removed, nothing to do", path.display());
-                    Ok(())
-                }
-                otherwise => otherwise,
-            }?;
-        }
+    let output_directory_name = output_directory_name
+        .or_else(|| module_descriptor.proto_out_dir.as_ref().map(Path::new))
+        .unwrap_or(Path::new(DEFAULT_OUTPUT_DIRECTORY_NAME));
+    let output_directory_path = root.join(output_directory_name);
 
-        Ok(())
-    } else {
-        Ok(())
+    info!(
+        "Cleaning protofetch proto_out source files folder {}.",
+        output_directory_path.display()
+    );
+    let output1 = std::fs::remove_dir_all(&output_directory_path);
+    let output2 = std::fs::remove_file(&lock_file_path);
+
+    for (output, path) in [(output1, output_directory_path), (output2, lock_file_path)] {
+        match output {
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                info!("{} is already removed, nothing to do", path.display());
+                Ok(())
+            }
+            otherwise => otherwise,
+        }?;
     }
+
+    Ok(())
 }
 
 pub fn do_clear_cache(cache: &ProtofetchGitCache) -> Result<(), Box<dyn Error>> {
@@ -165,20 +159,28 @@ pub fn do_clear_cache(cache: &ProtofetchGitCache) -> Result<(), Box<dyn Error>> 
     }
 }
 
+fn load_module_descriptor(
+    root: &Path,
+    module_file_name: &Path,
+) -> Result<Descriptor, Box<dyn Error>> {
+    let module_descriptor = Descriptor::from_file(&root.join(module_file_name)).or_else(|_| {
+        ProtodepDescriptor::from_file(&root.join("protodep.toml"))
+            .and_then(|d| d.into_proto_fetch())
+    })?;
+
+    Ok(module_descriptor)
+}
+
 /// Name if present otherwise attempt to extract from directory
 fn build_module_name(name: Option<String>, path: &Path) -> Result<String, Box<dyn Error>> {
     match name {
         Some(name) => Ok(name),
-        None => {
-            let filename = path.file_name();
-
-            match filename {
-                Some(dir) => Ok(dir.to_string_lossy().to_string()),
-                None => Err(
-                    "Module name not given and could not convert location to directory name".into(),
-                ),
+        None => match path.canonicalize()?.file_name() {
+            Some(dir) => Ok(dir.to_string_lossy().to_string()),
+            None => {
+                Err("Module name not given and could not convert location to directory name".into())
             }
-        }
+        },
     }
 }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -121,7 +121,6 @@ pub fn lock<Cache: RepositoryCache>(
 
     Ok(LockFile {
         module_name: descriptor.name.clone(),
-        proto_out_dir: descriptor.proto_out_dir.clone(),
         dependencies: locked_dependencies,
     })
 }

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -9,7 +9,6 @@ use super::{Coordinate, DependencyName, RevisionSpecification, Rules};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LockFile {
     pub module_name: String,
-    pub proto_out_dir: Option<String>,
     pub dependencies: Vec<LockedDependency>,
 }
 
@@ -53,7 +52,6 @@ mod tests {
     fn load_lock_file() {
         let lock_file = LockFile {
             module_name: "test".to_string(),
-            proto_out_dir: None,
             dependencies: vec![
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -482,7 +482,6 @@ mod tests {
             .join(Path::new("resources/cache"));
         let lock_file = LockFile {
             module_name: "test".to_string(),
-            proto_out_dir: None,
             dependencies: vec![
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
@@ -560,7 +559,6 @@ mod tests {
     fn collect_transitive_dependencies_test() {
         let lock_file = LockFile {
             module_name: "test".to_string(),
-            proto_out_dir: None,
             dependencies: vec![
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
@@ -622,7 +620,6 @@ mod tests {
     fn collect_all_root_dependencies_() {
         let lock_file = LockFile {
             module_name: "test".to_string(),
-            proto_out_dir: None,
             dependencies: vec![
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
@@ -662,7 +659,6 @@ mod tests {
     fn collect_all_root_dependencies_filtered() {
         let lock_file = LockFile {
             module_name: "test".to_string(),
-            proto_out_dir: None,
             dependencies: vec![
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
@@ -749,7 +745,6 @@ transitive = false
 "#;
         let lock_file = LockFile {
             module_name: "test".to_string(),
-            proto_out_dir: None,
             dependencies: vec![LockedDependency {
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
@@ -768,7 +763,6 @@ transitive = false
     fn parse_valid_lock_no_dep() {
         let lock_file = LockFile {
             module_name: "test".to_string(),
-            proto_out_dir: None,
             dependencies: vec![LockedDependency {
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),


### PR DESCRIPTION
There is no need to make output directory name a part of the lock file, we can alway get it from the module file. Also, we allow overriding it from the command line, which goes against having it "locked" too.