### PR TITLE
Remove specifications field from the lock file

### DIFF
--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -34,8 +34,6 @@ pub struct LockedDependency {
     pub name: DependencyName,
     pub commit_hash: String,
     pub coordinate: Coordinate,
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub specifications: Vec<LockedCoordinateRevisionSpecification>,
     #[serde(skip_serializing_if = "BTreeSet::is_empty", default)]
     pub dependencies: BTreeSet<DependencyName>,
     pub rules: Rules,
@@ -43,7 +41,7 @@ pub struct LockedDependency {
 
 #[cfg(test)]
 mod tests {
-    use crate::model::protofetch::{AllowPolicies, DenyPolicies, FilePolicy, Protocol, Revision};
+    use crate::model::protofetch::{AllowPolicies, DenyPolicies, FilePolicy, Protocol};
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -58,15 +56,6 @@ mod tests {
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
                         .unwrap(),
-                    specifications: vec![LockedCoordinateRevisionSpecification {
-                        coordinate: Some(
-                            Coordinate::from_url("example.com/org/dep1", Protocol::Https).unwrap(),
-                        ),
-                        specification: RevisionSpecification {
-                            revision: Revision::pinned("1.0.0"),
-                            branch: Some("main".to_owned()),
-                        },
-                    }],
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::new(
                         true,
@@ -84,7 +73,6 @@ mod tests {
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -449,7 +449,6 @@ mod tests {
             name: DependencyName::new("dep3".to_string()),
             commit_hash: "hash3".to_string(),
             coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https).unwrap(),
-            specifications: Vec::default(),
             dependencies: BTreeSet::new(),
             rules: Rules::new(
                 false,
@@ -488,7 +487,6 @@ mod tests {
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::new(
                         true,
@@ -506,7 +504,6 @@ mod tests {
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -565,7 +562,6 @@ mod tests {
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::from([
                         DependencyName::new("dep2".to_string()),
                         DependencyName::new("dep3".to_string()),
@@ -577,7 +573,6 @@ mod tests {
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -586,7 +581,6 @@ mod tests {
                     commit_hash: "hash3".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -595,7 +589,6 @@ mod tests {
                     commit_hash: "hash4".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep4", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::new(
                         false,
@@ -626,7 +619,6 @@ mod tests {
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -635,7 +627,6 @@ mod tests {
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -644,7 +635,6 @@ mod tests {
                     commit_hash: "hash3".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -665,7 +655,6 @@ mod tests {
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::default(),
                 },
@@ -674,7 +663,6 @@ mod tests {
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -683,7 +671,6 @@ mod tests {
                     commit_hash: "hash3".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::from([
                         DependencyName::new("dep2".to_string()),
                         DependencyName::new("dep5".to_string()),
@@ -699,7 +686,6 @@ mod tests {
                     commit_hash: "hash4".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep4", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -708,7 +694,6 @@ mod tests {
                     commit_hash: "hash5".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep5", Protocol::Https)
                         .unwrap(),
-                    specifications: Vec::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules {
                         prune: false,
@@ -749,7 +734,6 @@ transitive = false
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
                 coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
-                specifications: Vec::default(),
                 dependencies: BTreeSet::new(),
                 rules: Rules::default(),
             }],
@@ -767,7 +751,6 @@ transitive = false
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
                 coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
-                specifications: Vec::default(),
                 dependencies: BTreeSet::new(),
                 rules: Rules::default(),
             }],


### PR DESCRIPTION
Reverts https://github.com/coralogix/protofetch/pull/84.

This was a failed experiment, even with the `specifications` field the lock file doesn't contain enough information to resolve #83.

I'm going to implement a solution that doesn't rely on the `specifications` field, so let's remove it.
