### PR TITLE
Resolve to the "nearest" version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,12 +82,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "clap"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,24 +147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
-name = "downcast"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "either"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
-
-[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,15 +181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,12 +188,6 @@ checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fragile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "git2"
@@ -320,15 +281,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,12 +288,6 @@ checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -408,48 +354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "mockall"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
-dependencies = [
- "cfg-if",
- "downcast",
- "fragile",
- "lazy_static",
- "mockall_derive",
- "predicates",
- "predicates-tree",
-]
-
-[[package]]
-name = "mockall_derive"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,36 +400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
-name = "predicates"
-version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
-dependencies = [
- "difflib",
- "float-cmp",
- "itertools",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
-dependencies = [
- "predicates-core",
- "termtree",
-]
-
-[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,7 +434,6 @@ dependencies = [
  "git2",
  "home",
  "log",
- "mockall",
  "pretty_assertions",
  "project-root",
  "regex",
@@ -703,12 +576,6 @@ checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "termtree"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,5 @@ thiserror = "1.0.40"
 toml = "0.7.4"
 
 [dev-dependencies]
-mockall = "0.11.4"
 pretty_assertions = "1.4.0"
 project-root = "0.2.2"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -10,10 +10,7 @@ use crate::{
 };
 
 use crate::proto_repository::ProtoRepository;
-#[cfg(test)]
-use mockall::{predicate::*, *};
 
-#[cfg_attr(test, automock)]
 pub trait RepositoryCache {
     fn clone_or_update(&self, entry: &Coordinate) -> Result<Box<dyn ProtoRepository>, CacheError>;
 }

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     collections::HashMap,
-    fmt::{Debug, Display},
+    fmt::{Debug, Display, Write},
     path::{Path, PathBuf},
 };
 use strum::EnumString;
@@ -142,6 +142,15 @@ impl Revision {
     }
 }
 
+impl Display for Revision {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Revision::Pinned { revision } => f.write_str(revision),
+            Revision::Arbitrary => f.write_char('*'),
+        }
+    }
+}
+
 impl Serialize for Revision {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -200,6 +209,21 @@ pub struct RevisionSpecification {
     pub revision: Revision,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub branch: Option<String>,
+}
+
+impl Display for RevisionSpecification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RevisionSpecification {
+                revision,
+                branch: None,
+            } => write!(f, "{}", revision),
+            RevisionSpecification {
+                revision,
+                branch: Some(branch),
+            } => write!(f, "{}@{}", branch, revision),
+        }
+    }
 }
 
 #[derive(new, Clone, Serialize, Deserialize, Debug, Ord, PartialOrd, PartialEq, Eq, Hash)]
@@ -400,7 +424,7 @@ pub struct DependencyName {
     pub value: String,
 }
 
-#[derive(new, Debug, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(new, Debug, PartialEq, PartialOrd, Ord, Eq, Clone)]
 pub struct Dependency {
     pub name: DependencyName,
     pub coordinate: Coordinate,
@@ -408,7 +432,7 @@ pub struct Dependency {
     pub rules: Rules,
 }
 
-#[derive(new, PartialEq, Debug, PartialOrd, Ord, Eq)]
+#[derive(new, PartialEq, Debug, PartialOrd, Ord, Eq, Clone)]
 pub struct Descriptor {
     pub name: String,
     pub description: Option<String>,


### PR DESCRIPTION
Previously, when a dependency tree contained multiple versions of the same dependency we used the following rules to resolve the conflicts:

1. Prefer lexicographically greater revisions.
2. If there is a branch specification and a revision specification, try to use both and fail if the revision tag is not reachable from the specified branch head.

There are a few problems with these rules:
- Rule 1 does not give user much control over transitive dependency versions. You can only override to a bigger revision.
- Lexicographic comparison does not necessarily make sense for revision strings.
- Rule 2 does not work with some git workflows.
- There are some corner cases when transitive dependencies change depending on the version we choose.  

I'd say the first problem is the most important one, as it makes it impossible to work around other.

This PR implements an alternative conflict resolution strategy — the dependencies nearest to the root win. This is, for example, similar to what Maven does. This makes it trivial to override any dependency by explicitly specifying the revision in the `protofetch.toml`.

Besides making version resolution more flexible (which I suppose is rarely a problem in practice, as dependency trees are usually relatively small), there is a second reason why I'd like to make this change. With the current rules, transitive dependencies affect the dependency resolution but are not recorded in the lock file, so while the lock file stores the resulting revisions, it is impossible to verify that the lock file corresponds to `protofetch.toml`. An alternative solution could be to write all transitive dependencies in the lock file, even if they are not a part of the final dependency set. This is however not backwards compatible, and in my opinion it'd be nice to changing the resolution strategy anyway.