### PR TITLE
Create a more specialized trait for module resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +434,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 name = "protofetch"
 version = "0.0.28"
 dependencies = [
+ "anyhow",
  "clap",
  "derive-new",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ vendored-openssl = ["git2/vendored-openssl"]
 vendored-libgit2 = ["git2/vendored-libgit2"]
 
 [dependencies]
+anyhow = "1.0.75"
 clap = { version = "4.3.2", features = ["derive"] }
 derive-new = "0.5.9"
 env_logger = "0.10.0"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -12,7 +12,9 @@ use crate::{
 use crate::proto_repository::ProtoRepository;
 
 pub trait RepositoryCache {
-    fn clone_or_update(&self, entry: &Coordinate) -> Result<Box<dyn ProtoRepository>, CacheError>;
+    type Repository: ProtoRepository;
+
+    fn clone_or_update(&self, entry: &Coordinate) -> Result<Self::Repository, CacheError>;
 }
 
 pub struct ProtofetchGitCache {
@@ -32,7 +34,9 @@ pub enum CacheError {
 }
 
 impl RepositoryCache for ProtofetchGitCache {
-    fn clone_or_update(&self, entry: &Coordinate) -> Result<Box<dyn ProtoRepository>, CacheError> {
+    type Repository = ProtoGitRepository;
+
+    fn clone_or_update(&self, entry: &Coordinate) -> Result<Self::Repository, CacheError> {
         let repo = match self.get_entry(entry) {
             None => self.clone_repo(entry)?,
             Some(path) => {
@@ -44,7 +48,7 @@ impl RepositoryCache for ProtofetchGitCache {
             }
         };
 
-        Ok(Box::new(ProtoGitRepository::new(repo)))
+        Ok(ProtoGitRepository::new(repo))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ mod fetch;
 mod model;
 mod proto;
 mod proto_repository;
+mod resolver;
 
 pub use api::{Protofetch, ProtofetchBuilder};

--- a/src/resolver/git.rs
+++ b/src/resolver/git.rs
@@ -1,0 +1,23 @@
+use crate::{
+    cache::{ProtofetchGitCache, RepositoryCache},
+    model::protofetch::{Coordinate, DependencyName, RevisionSpecification},
+};
+
+use super::{ModuleResolver, ResolvedModule};
+
+impl ModuleResolver for ProtofetchGitCache {
+    fn resolve(
+        &self,
+        coordinate: &Coordinate,
+        specification: &RevisionSpecification,
+        name: &DependencyName,
+    ) -> anyhow::Result<ResolvedModule> {
+        let repository = self.clone_or_update(coordinate)?;
+        let commit_hash = repository.resolve_commit_hash(specification)?;
+        let descriptor = repository.extract_descriptor(name, &commit_hash)?;
+        Ok(ResolvedModule {
+            commit_hash,
+            descriptor,
+        })
+    }
+}

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1,0 +1,18 @@
+mod git;
+
+use crate::model::protofetch::{Coordinate, DependencyName, Descriptor, RevisionSpecification};
+
+pub trait ModuleResolver {
+    fn resolve(
+        &self,
+        coordinate: &Coordinate,
+        specification: &RevisionSpecification,
+        name: &DependencyName,
+    ) -> anyhow::Result<ResolvedModule>;
+}
+
+#[derive(Clone)]
+pub struct ResolvedModule {
+    pub commit_hash: String,
+    pub descriptor: Descriptor,
+}


### PR DESCRIPTION
Instead of an implementation-focused `RepositoryCache`, create a usecase-focused `ModuleResolver` trait. This trait allows other implementations (specifically, it should be possible to resolve dependencies using the existing lock-file) and it also allows more efficient implementation (not part of this PR, but in general we don't need to fetch all heads if we know the exact revision).

The `RepositoryCache` is still there, although with fewer methods, as it is also used when copying proto files.