### PR TITLE
Update the lock file when necessary

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -21,6 +21,16 @@ pub struct Protofetch {
     cache_dependencies_directory_name: PathBuf,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum LockMode {
+    /// Verify that the lock file is up to date. This mode should be normally used on CI.
+    Locked,
+    /// Update the lock file if necessary.
+    Update,
+    /// Recreate the lock file from scratch.
+    Recreate,
+}
+
 impl Protofetch {
     pub fn builder() -> ProtofetchBuilder {
         ProtofetchBuilder::default()
@@ -32,9 +42,9 @@ impl Protofetch {
     }
 
     /// Fetches dependencies defined in the toml configuration file
-    pub fn fetch(&self, ignore_lock_file: bool) -> Result<(), Box<dyn Error>> {
+    pub fn fetch(&self, lock_mode: LockMode) -> Result<(), Box<dyn Error>> {
         do_fetch(
-            ignore_lock_file,
+            lock_mode,
             &self.cache,
             &self.root,
             &self.module_file_name,
@@ -44,9 +54,10 @@ impl Protofetch {
         )
     }
 
-    /// Creates a lock file based on the toml configuration file
-    pub fn lock(&self) -> Result<(), Box<dyn Error>> {
+    /// Creates, updates or verifies a lock file based on the toml configuration file
+    pub fn lock(&self, lock_mode: LockMode) -> Result<(), Box<dyn Error>> {
         do_lock(
+            lock_mode,
             &self.cache,
             &self.root,
             &self.module_file_name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,4 @@ mod proto;
 mod proto_repository;
 mod resolver;
 
-pub use api::{Protofetch, ProtofetchBuilder};
+pub use api::{LockMode, Protofetch, ProtofetchBuilder};

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -34,6 +34,9 @@ pub struct LockedDependency {
     pub name: DependencyName,
     pub commit_hash: String,
     pub coordinate: Coordinate,
+    // default is needed for backwards compatibility with the existing lock files
+    #[serde(default, skip_serializing_if = "RevisionSpecification::is_default")]
+    pub specification: RevisionSpecification,
     #[serde(skip_serializing_if = "BTreeSet::is_empty", default)]
     pub dependencies: BTreeSet<DependencyName>,
     pub rules: Rules,
@@ -41,42 +44,46 @@ pub struct LockedDependency {
 
 #[cfg(test)]
 mod tests {
-    use crate::model::protofetch::{AllowPolicies, DenyPolicies, FilePolicy, Protocol};
+    use crate::model::protofetch::{AllowPolicies, DenyPolicies, FilePolicy, Protocol, Revision};
 
     use super::*;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn load_lock_file() {
+        let dependencies = vec![
+            LockedDependency {
+                name: DependencyName::new("dep1".to_string()),
+                commit_hash: "hash1".to_string(),
+                coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https).unwrap(),
+                specification: RevisionSpecification {
+                    revision: Revision::pinned("1.0.0"),
+                    branch: Some("main".to_owned()),
+                },
+                dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
+                rules: Rules::new(
+                    true,
+                    false,
+                    BTreeSet::new(),
+                    AllowPolicies::new(BTreeSet::from([FilePolicy::try_from_str(
+                        "/proto/example.proto",
+                    )
+                    .unwrap()])),
+                    DenyPolicies::default(),
+                ),
+            },
+            LockedDependency {
+                name: DependencyName::new("dep2".to_string()),
+                commit_hash: "hash2".to_string(),
+                coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
+                specification: RevisionSpecification::default(),
+                dependencies: BTreeSet::new(),
+                rules: Rules::default(),
+            },
+        ];
         let lock_file = LockFile {
             module_name: "test".to_string(),
-            dependencies: vec![
-                LockedDependency {
-                    name: DependencyName::new("dep1".to_string()),
-                    commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
-                    dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
-                    rules: Rules::new(
-                        true,
-                        false,
-                        BTreeSet::new(),
-                        AllowPolicies::new(BTreeSet::from([FilePolicy::try_from_str(
-                            "/proto/example.proto",
-                        )
-                        .unwrap()])),
-                        DenyPolicies::default(),
-                    ),
-                },
-                LockedDependency {
-                    name: DependencyName::new("dep2".to_string()),
-                    commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
-                    dependencies: BTreeSet::new(),
-                    rules: Rules::default(),
-                },
-            ],
+            dependencies,
         };
         let value_toml = toml::Value::try_from(&lock_file).unwrap();
         let string_fmt = toml::to_string_pretty(&value_toml).unwrap();

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -211,6 +211,12 @@ pub struct RevisionSpecification {
     pub branch: Option<String>,
 }
 
+impl RevisionSpecification {
+    pub fn is_default(&self) -> bool {
+        self.revision == Revision::Arbitrary && self.branch.is_none()
+    }
+}
+
 impl Display for RevisionSpecification {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -607,6 +613,11 @@ mod tests {
 
     use super::*;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn revision_specification_is_default() {
+        assert!(RevisionSpecification::default().is_default())
+    }
 
     #[test]
     fn load_valid_file_one_dep() {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -449,6 +449,7 @@ mod tests {
             name: DependencyName::new("dep3".to_string()),
             commit_hash: "hash3".to_string(),
             coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https).unwrap(),
+            specification: RevisionSpecification::default(),
             dependencies: BTreeSet::new(),
             rules: Rules::new(
                 false,
@@ -487,6 +488,7 @@ mod tests {
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::new(
                         true,
@@ -504,6 +506,7 @@ mod tests {
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -562,6 +565,7 @@ mod tests {
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::from([
                         DependencyName::new("dep2".to_string()),
                         DependencyName::new("dep3".to_string()),
@@ -573,6 +577,7 @@ mod tests {
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -581,6 +586,7 @@ mod tests {
                     commit_hash: "hash3".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -589,6 +595,7 @@ mod tests {
                     commit_hash: "hash4".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep4", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::new(
                         false,
@@ -619,6 +626,7 @@ mod tests {
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -627,6 +635,7 @@ mod tests {
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -635,6 +644,7 @@ mod tests {
                     commit_hash: "hash3".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -655,6 +665,7 @@ mod tests {
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::default(),
                 },
@@ -663,6 +674,7 @@ mod tests {
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -671,6 +683,7 @@ mod tests {
                     commit_hash: "hash3".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::from([
                         DependencyName::new("dep2".to_string()),
                         DependencyName::new("dep5".to_string()),
@@ -686,6 +699,7 @@ mod tests {
                     commit_hash: "hash4".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep4", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
@@ -694,6 +708,7 @@ mod tests {
                     commit_hash: "hash5".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep5", Protocol::Https)
                         .unwrap(),
+                    specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules {
                         prune: false,
@@ -734,6 +749,7 @@ transitive = false
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
                 coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
+                specification: RevisionSpecification::default(),
                 dependencies: BTreeSet::new(),
                 rules: Rules::default(),
             }],
@@ -751,6 +767,7 @@ transitive = false
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
                 coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
+                specification: RevisionSpecification::default(),
                 dependencies: BTreeSet::new(),
                 rules: Rules::default(),
             }],

--- a/src/resolver/lock.rs
+++ b/src/resolver/lock.rs
@@ -1,0 +1,66 @@
+use anyhow::bail;
+use log::debug;
+
+use crate::model::protofetch::{lock::LockFile, Coordinate, DependencyName, RevisionSpecification};
+
+use super::{ModuleResolver, ResolvedModule};
+
+pub struct LockFileModuleResolver<R> {
+    inner: R,
+    lock_file: LockFile,
+    locked: bool,
+}
+
+impl<R> LockFileModuleResolver<R> {
+    pub fn new(inner: R, lock_file: LockFile, locked: bool) -> Self {
+        Self {
+            inner,
+            lock_file,
+            locked,
+        }
+    }
+}
+
+impl<R> ModuleResolver for LockFileModuleResolver<R>
+where
+    R: ModuleResolver,
+{
+    fn resolve(
+        &self,
+        coordinate: &Coordinate,
+        specification: &RevisionSpecification,
+        name: &DependencyName,
+    ) -> anyhow::Result<ResolvedModule> {
+        let dependency = self.lock_file.dependencies.iter().find(|dependency| {
+            &dependency.coordinate == coordinate && &dependency.specification == specification
+        });
+        match dependency {
+            Some(dependency) => {
+                debug!(
+                    "Dependency {} {} found in the lock file with commit {}",
+                    coordinate, specification, dependency.commit_hash
+                );
+                let commit_hash = dependency.commit_hash.clone();
+                let resolved = self.inner.resolve(coordinate, specification, name)?;
+                if resolved.commit_hash != commit_hash {
+                    bail!("Commit hash of {} {} changed: the lock file specifies {}, but the actual commit hash is {}", coordinate, specification, commit_hash, resolved.commit_hash);
+                }
+                Ok(resolved)
+            }
+            None if self.locked => {
+                bail!(
+                    "No entry for {} {} in the lock file",
+                    coordinate,
+                    specification
+                );
+            }
+            None => {
+                debug!(
+                    "Dependency {} {} not found in the lock file",
+                    coordinate, specification
+                );
+                self.inner.resolve(coordinate, specification, name)
+            }
+        }
+    }
+}

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1,6 +1,9 @@
 mod git;
+mod lock;
 
 use crate::model::protofetch::{Coordinate, DependencyName, Descriptor, RevisionSpecification};
+
+pub use lock::LockFileModuleResolver;
 
 pub trait ModuleResolver {
     fn resolve(
@@ -15,4 +18,18 @@ pub trait ModuleResolver {
 pub struct ResolvedModule {
     pub commit_hash: String,
     pub descriptor: Descriptor,
+}
+
+impl<T> ModuleResolver for &T
+where
+    T: ModuleResolver,
+{
+    fn resolve(
+        &self,
+        coordinate: &Coordinate,
+        specification: &RevisionSpecification,
+        name: &DependencyName,
+    ) -> anyhow::Result<ResolvedModule> {
+        T::resolve(self, coordinate, specification, name)
+    }
 }


### PR DESCRIPTION
The PR is created as a draft, as it includes changes from https://github.com/coralogix/protofetch/pull/109.

Closes #83.

### CLI changes
- `protofetch fetch`: updates `protofetch.lock` if `protofetch.toml` has changed. Previous behavior: ignore `protofetch.toml` even if changed, fetch whatever `protofetch.lock` says.
- `protofetch fetch --locked`: verifies that the lock file is up-to-date and fails otherwise
- `protofetch fetch --force-lock`: deprecated, but still works for backwards compatibility.
- `protofetch update`: recreates the lock file, like `fetch --force-lock` used to, but does not actually fetch the protos

It is possible to keep `--force-lock`, but I think it'd better to deprecate this flag:
- it's poorly named, the name looks like it forces protofetch to use the lock file, but in fact it's the opposite
- it combines two steps (recreating the lock file, and fetching the protos), which should be rarely needed. It should be more common to only want to recreate the lock file, and fetching the protos is usually a part of some build script.

### API changes
`fetch` and `lock` now accept a `LockMode` enum. 

### Compatibility
- older versions of protofetch seamlessly use the new lock files
- the new versions of protofetch will have to update old lock files, `fetch --locked` will not succeed unless the updated lock file is available.