### PR TITLE
Remove deprecated CLI options

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -18,7 +18,6 @@ pub struct Protofetch {
     module_file_name: PathBuf,
     lock_file_name: PathBuf,
     output_directory_name: Option<PathBuf>,
-    cache_dependencies_directory_name: PathBuf,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -49,7 +48,6 @@ impl Protofetch {
             &self.root,
             &self.module_file_name,
             &self.lock_file_name,
-            &self.cache_dependencies_directory_name,
             self.output_directory_name.as_deref(),
         )
     }

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -17,6 +17,7 @@ use std::{
 };
 
 const DEFAULT_OUTPUT_DIRECTORY_NAME: &str = "proto_src";
+const CACHE_WORKSPACES_DIRECTORY_NAME: &str = "dependencies";
 
 /// Handler to fetch command
 pub fn do_fetch(
@@ -25,14 +26,13 @@ pub fn do_fetch(
     root: &Path,
     module_file_name: &Path,
     lock_file_name: &Path,
-    cache_dependencies_directory_name: &Path,
     output_directory_name: Option<&Path>,
 ) -> Result<(), Box<dyn Error>> {
     let module_descriptor = load_module_descriptor(root, module_file_name)?;
 
     let lockfile = do_lock(lock_mode, cache, root, module_file_name, lock_file_name)?;
 
-    let cache_dependencies_directory_path = cache.location.join(cache_dependencies_directory_name);
+    let cache_dependencies_directory_path = cache.location.join(CACHE_WORKSPACES_DIRECTORY_NAME);
     let output_directory_name = output_directory_name
         .or_else(|| module_descriptor.proto_out_dir.as_ref().map(Path::new))
         .unwrap_or(Path::new(DEFAULT_OUTPUT_DIRECTORY_NAME));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,9 +1,1 @@
-use derive_new::new;
-
 pub mod command_handlers;
-
-#[derive(Clone, Debug, new)]
-pub struct HttpGitAuth {
-    pub username: String,
-    pub password: String,
-}


### PR DESCRIPTION
- `--username` and `--password`: GIT credential helper is used instead for HTTP auth
- `--repo-output-directory`: there should be no reason to let a user override this