### PR TITLE
Do not fail if a branch has other commits than the lock file

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -54,6 +54,7 @@ pub fn lock(
                         .resolve(
                             &dependency.coordinate,
                             &dependency.specification,
+                            None,
                             &dependency.name,
                         )
                         .map_err(FetchError::Resolver)?;
@@ -194,6 +195,7 @@ mod tests {
             &self,
             coordinate: &Coordinate,
             specification: &RevisionSpecification,
+            _: Option<&str>,
             _: &DependencyName,
         ) -> anyhow::Result<ResolvedModule> {
             Ok(self

--- a/src/resolver/git.rs
+++ b/src/resolver/git.rs
@@ -1,6 +1,6 @@
 use crate::{
     cache::{ProtofetchGitCache, RepositoryCache},
-    model::protofetch::{Coordinate, DependencyName, RevisionSpecification},
+    model::protofetch::{Coordinate, DependencyName, Revision, RevisionSpecification},
 };
 
 use super::{ModuleResolver, ResolvedModule};
@@ -10,10 +10,19 @@ impl ModuleResolver for ProtofetchGitCache {
         &self,
         coordinate: &Coordinate,
         specification: &RevisionSpecification,
+        commit_hash: Option<&str>,
         name: &DependencyName,
     ) -> anyhow::Result<ResolvedModule> {
         let repository = self.clone_or_update(coordinate)?;
-        let commit_hash = repository.resolve_commit_hash(specification)?;
+        let commit_hash = if specification.revision == Revision::Arbitrary {
+            if let Some(commit_hash) = commit_hash {
+                commit_hash.to_owned()
+            } else {
+                repository.resolve_commit_hash(specification)?
+            }
+        } else {
+            repository.resolve_commit_hash(specification)?
+        };
         let descriptor = repository.extract_descriptor(name, &commit_hash)?;
         Ok(ResolvedModule {
             commit_hash,

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -10,6 +10,7 @@ pub trait ModuleResolver {
         &self,
         coordinate: &Coordinate,
         specification: &RevisionSpecification,
+        commit_hash: Option<&str>,
         name: &DependencyName,
     ) -> anyhow::Result<ResolvedModule>;
 }
@@ -28,8 +29,9 @@ where
         &self,
         coordinate: &Coordinate,
         specification: &RevisionSpecification,
+        commit_hash: Option<&str>,
         name: &DependencyName,
     ) -> anyhow::Result<ResolvedModule> {
-        T::resolve(self, coordinate, specification, name)
+        T::resolve(self, coordinate, specification, commit_hash, name)
     }
 }


### PR DESCRIPTION
If `protofetch.toml` specifies a branch, having other commits on this branch should not be an error (but we still should use the commit from the lock file).

However, if `protofetch.toml` specifies a revision, and this revision starts resolving to a different commit, I think we should report this.