### PR TITLE
Make sure all cache access is encapsulated in the ProtofetchGitCache

### DIFF
--- a/src/api/builder.rs
+++ b/src/api/builder.rs
@@ -2,7 +2,7 @@ use std::{env, error::Error, path::PathBuf};
 
 use home::home_dir;
 
-use crate::{cache::ProtofetchGitCache, Protofetch};
+use crate::{git::cache::ProtofetchGitCache, Protofetch};
 
 #[derive(Default)]
 pub struct ProtofetchBuilder {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::{
-    cache::ProtofetchGitCache,
     cli::command_handlers::{do_clean, do_fetch, do_init, do_lock, do_migrate},
+    git::cache::ProtofetchGitCache,
 };
 
 mod builder;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     cache::ProtofetchGitCache,
-    cli::command_handlers::{do_clean, do_clear_cache, do_fetch, do_init, do_lock, do_migrate},
+    cli::command_handlers::{do_clean, do_fetch, do_init, do_lock, do_migrate},
 };
 
 mod builder;
@@ -89,6 +89,7 @@ impl Protofetch {
     }
 
     pub fn clear_cache(&self) -> Result<(), Box<dyn Error>> {
-        do_clear_cache(&self.cache)
+        self.cache.clear()?;
+        Ok(())
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use git2::Config;
 use git2::{build::RepoBuilder, Cred, CredentialType, FetchOptions, RemoteCallbacks, Repository};
-use log::trace;
+use log::{info, trace};
 use thiserror::Error;
 
 use crate::{model::protofetch::Coordinate, proto_repository::ProtoGitRepository};
@@ -67,6 +67,17 @@ impl ProtofetchGitCache {
                 location: location.to_str().unwrap_or("").to_string(),
             })
         }
+    }
+
+    pub fn clear(&self) -> anyhow::Result<()> {
+        if self.location.exists() {
+            info!(
+                "Clearing protofetch repository cache {}.",
+                &self.location.display()
+            );
+            std::fs::remove_dir_all(&self.location)?;
+        }
+        Ok(())
     }
 
     fn get_entry(&self, entry: &Coordinate) -> Option<PathBuf> {

--- a/src/cache/git.rs
+++ b/src/cache/git.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use crate::{
+    git::cache::ProtofetchGitCache,
+    model::protofetch::{Coordinate, DependencyName, RevisionSpecification},
+};
+
+use super::RepositoryCache;
+
+impl RepositoryCache for ProtofetchGitCache {
+    fn fetch(
+        &self,
+        coordinate: &Coordinate,
+        specification: &RevisionSpecification,
+        _commit_hash: &str,
+    ) -> anyhow::Result<()> {
+        self.clone_or_update(coordinate)?
+            .resolve_commit_hash(specification)?;
+        Ok(())
+    }
+
+    fn create_worktree(
+        &self,
+        coordinate: &Coordinate,
+        commit_hash: &str,
+        name: &DependencyName,
+    ) -> anyhow::Result<PathBuf> {
+        let path = self
+            .clone_or_update(coordinate)?
+            .create_worktree(name, commit_hash)?;
+        Ok(path)
+    }
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,21 @@
+mod git;
+
+use std::path::PathBuf;
+
+use crate::model::protofetch::{Coordinate, DependencyName, RevisionSpecification};
+
+pub trait RepositoryCache {
+    fn fetch(
+        &self,
+        coordinate: &Coordinate,
+        specification: &RevisionSpecification,
+        commit_hash: &str,
+    ) -> anyhow::Result<()>;
+
+    fn create_worktree(
+        &self,
+        coordinate: &Coordinate,
+        commit_hash: &str,
+        name: &DependencyName,
+    ) -> anyhow::Result<PathBuf>;
+}

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -2,8 +2,8 @@ use log::{debug, info};
 
 use crate::{
     api::LockMode,
-    cache::ProtofetchGitCache,
     fetch,
+    git::cache::ProtofetchGitCache,
     model::{
         protodep::ProtodepDescriptor,
         protofetch::{lock::LockFile, Descriptor},
@@ -17,7 +17,6 @@ use std::{
 };
 
 const DEFAULT_OUTPUT_DIRECTORY_NAME: &str = "proto_src";
-const CACHE_WORKSPACES_DIRECTORY_NAME: &str = "dependencies";
 
 /// Handler to fetch command
 pub fn do_fetch(
@@ -32,18 +31,13 @@ pub fn do_fetch(
 
     let lockfile = do_lock(lock_mode, cache, root, module_file_name, lock_file_name)?;
 
-    let cache_dependencies_directory_path = cache.location.join(CACHE_WORKSPACES_DIRECTORY_NAME);
     let output_directory_name = output_directory_name
         .or_else(|| module_descriptor.proto_out_dir.as_ref().map(Path::new))
         .unwrap_or(Path::new(DEFAULT_OUTPUT_DIRECTORY_NAME));
-    fetch::fetch_sources(cache, &lockfile, &cache_dependencies_directory_path)?;
+    fetch::fetch_sources(cache, &lockfile)?;
 
     //Copy proto_out files to actual target
-    proto::copy_proto_files(
-        &root.join(output_directory_name),
-        &cache_dependencies_directory_path,
-        &lockfile,
-    )?;
+    proto::copy_proto_files(cache, &lockfile, &root.join(output_directory_name))?;
 
     Ok(())
 }

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -177,19 +177,6 @@ pub fn do_clean(
     Ok(())
 }
 
-pub fn do_clear_cache(cache: &ProtofetchGitCache) -> Result<(), Box<dyn Error>> {
-    if cache.location.exists() {
-        info!(
-            "Clearing protofetch repository cache {}.",
-            &cache.location.display()
-        );
-        std::fs::remove_dir_all(&cache.location)?;
-        Ok(())
-    } else {
-        Ok(())
-    }
-}
-
 fn load_module_descriptor(
     root: &Path,
     module_file_name: &Path,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,0 +1,2 @@
+pub mod cache;
+pub mod repository;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@ mod api;
 mod cache;
 mod cli;
 mod fetch;
+mod git;
 mod model;
 mod proto;
-mod proto_repository;
 mod resolver;
 
 pub use api::{LockMode, Protofetch, ProtofetchBuilder};

--- a/src/resolver/git.rs
+++ b/src/resolver/git.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cache::{ProtofetchGitCache, RepositoryCache},
+    git::cache::ProtofetchGitCache,
     model::protofetch::{Coordinate, DependencyName, Revision, RevisionSpecification},
 };
 


### PR DESCRIPTION
Previously, the `ProtofetchGitCache` was used to create a worktree, but then the code used the shared knowledge about the cache layout to access the files. This PR moves all this logic to ProtofetchGitCache.