### PR TITLE
Lockfile v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,18 +759,18 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,12 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +338,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,12 +382,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
- "autocfg",
- "hashbrown",
+ "equivalent",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -566,7 +572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -675,7 +681,7 @@ dependencies = [
  "serde",
  "strum",
  "thiserror",
- "toml 0.7.4",
+ "toml 0.8.6",
 ]
 
 [[package]]
@@ -784,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -907,10 +913,11 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+checksum = "8ff9e3abce27ee2c9a37f9ad37238c1bdd4e789c84ba37df76aa4d528f5072cc"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -919,18 +926,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap",
  "serde",
@@ -1106,9 +1113,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "176b6138793677221d420fd2f0aeeced263f197688b36484660da767bca2fa32"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ git2 = "0.17.2"
 home = "0.5.5"
 log = "0.4.18"
 regex = "1.8.4"
-serde = { version = "1.0.163", features = ["derive"] }
+serde = { version = "1.0.190", features = ["derive"] }
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.40"
 toml = { version = "0.8.6", features = ["preserve_order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ regex = "1.8.4"
 serde = { version = "1.0.163", features = ["derive"] }
 strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.40"
-toml = "0.7.4"
+toml = { version = "0.8.6", features = ["preserve_order"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/src/cache/git.rs
+++ b/src/cache/git.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::{
     git::cache::ProtofetchGitCache,
-    model::protofetch::{Coordinate, DependencyName, RevisionSpecification},
+    model::protofetch::{Coordinate, ModuleName, RevisionSpecification},
 };
 
 use super::RepositoryCache;
@@ -23,7 +23,7 @@ impl RepositoryCache for ProtofetchGitCache {
         &self,
         coordinate: &Coordinate,
         commit_hash: &str,
-        name: &DependencyName,
+        name: &ModuleName,
     ) -> anyhow::Result<PathBuf> {
         let path = self
             .repository(coordinate)?

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -2,7 +2,7 @@ mod git;
 
 use std::path::PathBuf;
 
-use crate::model::protofetch::{Coordinate, DependencyName, RevisionSpecification};
+use crate::model::protofetch::{Coordinate, ModuleName, RevisionSpecification};
 
 pub trait RepositoryCache {
     fn fetch(
@@ -16,6 +16,6 @@ pub trait RepositoryCache {
         &self,
         coordinate: &Coordinate,
         commit_hash: &str,
-        name: &DependencyName,
+        name: &ModuleName,
     ) -> anyhow::Result<PathBuf>;
 }

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -6,7 +6,7 @@ use crate::{
     git::cache::ProtofetchGitCache,
     model::{
         protodep::ProtodepDescriptor,
-        protofetch::{lock::LockFile, resolved::ResolvedModule, Descriptor},
+        protofetch::{lock::LockFile, resolved::ResolvedModule, Descriptor, ModuleName},
     },
     proto,
     resolver::LockFileModuleResolver,
@@ -184,11 +184,11 @@ fn load_module_descriptor(
 }
 
 /// Name if present otherwise attempt to extract from directory
-fn build_module_name(name: Option<String>, path: &Path) -> Result<String, Box<dyn Error>> {
+fn build_module_name(name: Option<String>, path: &Path) -> Result<ModuleName, Box<dyn Error>> {
     match name {
-        Some(name) => Ok(name),
+        Some(name) => Ok(ModuleName::from(name)),
         None => match path.canonicalize()?.file_name() {
-            Some(dir) => Ok(dir.to_string_lossy().to_string()),
+            Some(dir) => Ok(ModuleName::from(dir.to_string_lossy().to_string())),
             None => {
                 Err("Module name not given and could not convert location to directory name".into())
             }

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -91,9 +91,8 @@ pub fn do_lock(
     if old_lock.is_some_and(|old_lock| old_lock == lockfile) {
         debug!("Lockfile is up to date");
     } else {
-        let value_toml = toml::Value::try_from(&lockfile)?;
         let lock_file_path = root.join(lock_file_name);
-        std::fs::write(&lock_file_path, toml::to_string_pretty(&value_toml)?)?;
+        std::fs::write(&lock_file_path, lockfile.to_string()?)?;
         info!("Wrote lockfile to {}", lock_file_path.display());
     }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -118,7 +118,6 @@ pub fn resolve(
     };
 
     let lockfile = LockFile {
-        module_name: descriptor.name.clone(),
         dependencies: locked,
     };
 
@@ -263,7 +262,6 @@ mod tests {
         assert_eq!(
             lockfile,
             LockFile {
-                module_name: ModuleName::from("root"),
                 dependencies: vec![
                     locked_dependency("bar", "2.0.0", "c2"),
                     locked_dependency("foo", "1.0.0", "c1")
@@ -324,7 +322,6 @@ mod tests {
         assert_eq!(
             lockfile,
             LockFile {
-                module_name: ModuleName::from("root"),
                 dependencies: vec![
                     locked_dependency("bar", "1.0.0", "c3"),
                     locked_dependency("foo", "1.0.0", "c1"),

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -20,4 +20,8 @@ pub enum ParseError {
     ParsePolicyRuleError(String),
     #[error("Missing url component `{0}` in string `{1}`")]
     MissingUrlComponent(String, String),
+    #[error("Unsupported lock file version {0}")]
+    UnsupportedLockFileVersion(toml::Value),
+    #[error("Old lock file version {0}, consider running \"protofetch update\"")]
+    OldLockFileVersion(i64),
 }

--- a/src/model/protodep.rs
+++ b/src/model/protodep.rs
@@ -1,7 +1,7 @@
 use crate::model::{
     protofetch::{
-        Coordinate, Dependency as ProtofetchDependency, DependencyName, Descriptor, Protocol,
-        Revision, RevisionSpecification, Rules,
+        Coordinate, Dependency as ProtofetchDependency, Descriptor, ModuleName, Protocol, Revision,
+        RevisionSpecification, Rules,
     },
     ParseError,
 };
@@ -79,7 +79,7 @@ impl ProtodepDescriptor {
                 revision: Revision::pinned(d.revision),
                 branch: d.branch,
             };
-            let name = DependencyName::new(coordinate.repository.clone());
+            let name = ModuleName::new(coordinate.repository.clone());
             Ok(ProtofetchDependency {
                 name,
                 coordinate,
@@ -95,7 +95,7 @@ impl ProtodepDescriptor {
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Descriptor {
-            name: "generated".to_string(),
+            name: ModuleName::from("generated"),
             description: Some("Generated from protodep file".to_string()),
             proto_out_dir: self.proto_out_dir.into(),
             dependencies,

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -32,11 +32,11 @@ pub struct LockedCoordinateRevisionSpecification {
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct LockedDependency {
     pub name: ModuleName,
-    pub commit_hash: String,
     #[serde(flatten)]
     pub coordinate: Coordinate,
     #[serde(flatten)]
     pub specification: RevisionSpecification,
+    pub commit_hash: String,
 }
 
 #[cfg(test)]

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -1,10 +1,10 @@
-use std::{collections::BTreeSet, path::Path};
+use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
 use crate::model::ParseError;
 
-use super::{Coordinate, DependencyName, RevisionSpecification, Rules};
+use super::{Coordinate, DependencyName, RevisionSpecification};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LockFile {
@@ -34,17 +34,12 @@ pub struct LockedDependency {
     pub name: DependencyName,
     pub commit_hash: String,
     pub coordinate: Coordinate,
-    // default is needed for backwards compatibility with the existing lock files
-    #[serde(default, skip_serializing_if = "RevisionSpecification::is_default")]
     pub specification: RevisionSpecification,
-    #[serde(skip_serializing_if = "BTreeSet::is_empty", default)]
-    pub dependencies: BTreeSet<DependencyName>,
-    pub rules: Rules,
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::model::protofetch::{AllowPolicies, DenyPolicies, FilePolicy, Protocol, Revision};
+    use crate::model::protofetch::{Protocol, Revision};
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -64,25 +59,12 @@ mod tests {
                     revision: Revision::pinned("1.0.0"),
                     branch: Some("main".to_owned()),
                 },
-                dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
-                rules: Rules::new(
-                    true,
-                    false,
-                    BTreeSet::new(),
-                    AllowPolicies::new(BTreeSet::from([FilePolicy::try_from_str(
-                        "/proto/example.proto",
-                    )
-                    .unwrap()])),
-                    DenyPolicies::default(),
-                ),
             },
             LockedDependency {
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
                 coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                 specification: RevisionSpecification::default(),
-                dependencies: BTreeSet::new(),
-                rules: Rules::default(),
             },
         ];
         let lock_file = LockFile {

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -8,7 +8,6 @@ use super::{Coordinate, ModuleName, RevisionSpecification};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LockFile {
-    pub module_name: ModuleName,
     pub dependencies: Vec<LockedDependency>,
 }
 
@@ -69,10 +68,7 @@ mod tests {
                 specification: RevisionSpecification::default(),
             },
         ];
-        let lock_file = LockFile {
-            module_name: ModuleName::from("test"),
-            dependencies,
-        };
+        let lock_file = LockFile { dependencies };
         let value_toml = toml::Value::try_from(&lock_file).unwrap();
         let string_fmt = toml::to_string_pretty(&value_toml).unwrap();
 

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -33,7 +33,9 @@ pub struct LockedCoordinateRevisionSpecification {
 pub struct LockedDependency {
     pub name: ModuleName,
     pub commit_hash: String,
+    #[serde(flatten)]
     pub coordinate: Coordinate,
+    #[serde(flatten)]
     pub specification: RevisionSpecification,
 }
 

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -11,12 +11,34 @@ pub struct LockFile {
     pub dependencies: Vec<LockedDependency>,
 }
 
-impl LockFile {
-    pub fn from_file(loc: &Path) -> Result<LockFile, ParseError> {
-        let contents = std::fs::read_to_string(loc)?;
-        let lockfile = toml::from_str::<LockFile>(&contents)?;
+const VERSION: i64 = 2;
 
-        Ok(lockfile)
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct VersionedLockFile<'a> {
+    pub version: i64,
+    #[serde(flatten)]
+    pub content: &'a LockFile,
+}
+
+impl LockFile {
+    pub fn from_file(file: &Path) -> Result<LockFile, ParseError> {
+        LockFile::from_str(&std::fs::read_to_string(file)?)
+    }
+
+    pub fn from_str(s: &str) -> Result<LockFile, ParseError> {
+        let mut table = toml::from_str::<toml::Table>(s)?;
+        match table.remove("version") {
+            Some(toml::Value::Integer(VERSION)) => table.try_into::<LockFile>().map_err(Into::into),
+            Some(other) => Err(ParseError::UnsupportedLockFileVersion(other)),
+            None => Err(ParseError::OldLockFileVersion(1)),
+        }
+    }
+
+    pub fn to_string(&self) -> Result<String, toml::ser::Error> {
+        toml::to_string_pretty(&VersionedLockFile {
+            version: VERSION,
+            content: self,
+        })
     }
 }
 
@@ -40,39 +62,72 @@ pub struct LockedDependency {
 
 #[cfg(test)]
 mod tests {
+    use toml::toml;
+
     use crate::model::protofetch::{Protocol, Revision};
 
     use super::*;
+
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn load_lock_file() {
-        let dependencies = vec![
-            LockedDependency {
-                name: ModuleName::new("dep1".to_string()),
-                commit_hash: "hash1".to_string(),
-                coordinate: Coordinate::from_url_protocol(
-                    "example.com/org/dep1",
-                    Some(Protocol::Https),
-                )
-                .unwrap(),
-                specification: RevisionSpecification {
-                    revision: Revision::pinned("1.0.0"),
-                    branch: Some("main".to_owned()),
-                },
-            },
-            LockedDependency {
-                name: ModuleName::new("dep2".to_string()),
-                commit_hash: "hash2".to_string(),
-                coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
-                specification: RevisionSpecification::default(),
-            },
-        ];
-        let lock_file = LockFile { dependencies };
-        let value_toml = toml::Value::try_from(&lock_file).unwrap();
-        let string_fmt = toml::to_string_pretty(&value_toml).unwrap();
+    fn load_save_lock_file() {
+        let text = toml::to_string_pretty(&toml! {
+            version = 2
 
-        let new_lock_file = toml::from_str::<LockFile>(&string_fmt).unwrap();
-        assert_eq!(lock_file, new_lock_file)
+            [[dependencies]]
+            name = "dep1"
+            forge = "example.com"
+            organization = "org"
+            repository = "dep1"
+            protocol = "https"
+            revision = "1.0.0"
+            branch = "main"
+            commit_hash = "hash1"
+
+            [[dependencies]]
+            name = "dep2"
+            forge = "example.com"
+            organization = "org"
+            repository = "dep2"
+            commit_hash = "hash2"
+        })
+        .unwrap();
+        let data = LockFile {
+            dependencies: vec![
+                LockedDependency {
+                    name: ModuleName::new("dep1".to_string()),
+                    commit_hash: "hash1".to_string(),
+                    coordinate: Coordinate::from_url_protocol(
+                        "example.com/org/dep1",
+                        Some(Protocol::Https),
+                    )
+                    .unwrap(),
+                    specification: RevisionSpecification {
+                        revision: Revision::pinned("1.0.0"),
+                        branch: Some("main".to_owned()),
+                    },
+                },
+                LockedDependency {
+                    name: ModuleName::new("dep2".to_string()),
+                    commit_hash: "hash2".to_string(),
+                    coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
+                    specification: RevisionSpecification::default(),
+                },
+            ],
+        };
+        let parsed = LockFile::from_str(&text).unwrap();
+        let formatted = data.to_string().unwrap();
+        assert_eq!(parsed, data);
+        assert_eq!(formatted, text);
+    }
+
+    #[test]
+    fn load_lock_file_v1() {
+        let text = toml::to_string_pretty(&toml! {
+            module_name = "foo"
+        })
+        .unwrap();
+        LockFile::from_str(&text).expect_err("should not parse v1 lock file");
     }
 }

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -4,11 +4,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::ParseError;
 
-use super::{Coordinate, DependencyName, RevisionSpecification};
+use super::{Coordinate, ModuleName, RevisionSpecification};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LockFile {
-    pub module_name: String,
+    pub module_name: ModuleName,
     pub dependencies: Vec<LockedDependency>,
 }
 
@@ -31,7 +31,7 @@ pub struct LockedCoordinateRevisionSpecification {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct LockedDependency {
-    pub name: DependencyName,
+    pub name: ModuleName,
     pub commit_hash: String,
     pub coordinate: Coordinate,
     pub specification: RevisionSpecification,
@@ -48,7 +48,7 @@ mod tests {
     fn load_lock_file() {
         let dependencies = vec![
             LockedDependency {
-                name: DependencyName::new("dep1".to_string()),
+                name: ModuleName::new("dep1".to_string()),
                 commit_hash: "hash1".to_string(),
                 coordinate: Coordinate::from_url_protocol(
                     "example.com/org/dep1",
@@ -61,14 +61,14 @@ mod tests {
                 },
             },
             LockedDependency {
-                name: DependencyName::new("dep2".to_string()),
+                name: ModuleName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
                 coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                 specification: RevisionSpecification::default(),
             },
         ];
         let lock_file = LockFile {
-            module_name: "test".to_string(),
+            module_name: ModuleName::from("test"),
             dependencies,
         };
         let value_toml = toml::Value::try_from(&lock_file).unwrap();

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -429,13 +429,35 @@ pub enum PolicyKind {
 }
 
 #[derive(new, Clone, Hash, Deserialize, Serialize, Debug, PartialEq, Eq, Ord, PartialOrd)]
-pub struct DependencyName {
-    pub value: String,
+pub struct ModuleName(String);
+
+impl ModuleName {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for ModuleName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for ModuleName {
+    fn from(s: String) -> Self {
+        ModuleName(s)
+    }
+}
+
+impl From<&str> for ModuleName {
+    fn from(s: &str) -> Self {
+        ModuleName(s.to_string())
+    }
 }
 
 #[derive(new, Debug, PartialEq, PartialOrd, Ord, Eq, Clone)]
 pub struct Dependency {
-    pub name: DependencyName,
+    pub name: ModuleName,
     pub coordinate: Coordinate,
     pub specification: RevisionSpecification,
     pub rules: Rules,
@@ -443,7 +465,7 @@ pub struct Dependency {
 
 #[derive(new, PartialEq, Debug, PartialOrd, Ord, Eq, Clone)]
 pub struct Descriptor {
-    pub name: String,
+    pub name: ModuleName,
     pub description: Option<String>,
     pub proto_out_dir: Option<String>,
     pub dependencies: Vec<Dependency>,
@@ -472,7 +494,7 @@ impl Descriptor {
         let name = toml_value
             .remove("name")
             .ok_or_else(|| ParseError::MissingKey("name".to_string()))
-            .and_then(|v| v.try_into::<String>().map_err(|e| e.into()))?;
+            .and_then(|v| v.try_into::<ModuleName>().map_err(|e| e.into()))?;
 
         let description = toml_value
             .remove("description")
@@ -499,7 +521,7 @@ impl Descriptor {
 
     pub fn into_toml(self) -> Value {
         let mut description = Map::new();
-        description.insert("name".to_string(), Value::String(self.name));
+        description.insert("name".to_string(), Value::String(self.name.to_string()));
         if let Some(d) = self.description {
             description.insert("description".to_string(), Value::String(d));
         }
@@ -519,7 +541,7 @@ impl Descriptor {
             if let Some(branch) = d.specification.branch {
                 dependency.insert("branch".to_owned(), Value::String(branch));
             }
-            description.insert(d.name.value, Value::Table(dependency));
+            description.insert(d.name.to_string(), Value::Table(dependency));
         }
         Value::Table(description)
     }
@@ -531,7 +553,7 @@ fn parse_dependency(name: String, value: &toml::Value) -> Result<Dependency, Par
         Some(toml) => Some(toml.clone().try_into::<Protocol>()?),
     };
 
-    let name = DependencyName::new(name);
+    let name = ModuleName::new(name);
 
     let branch = value
         .get("branch")
@@ -628,11 +650,11 @@ mod tests {
                 revision = "1.0.0"
         "#;
         let expected = Descriptor {
-            name: "test_file".to_string(),
+            name: ModuleName::from("test_file"),
             description: Some("this is a description".to_string()),
             proto_out_dir: Some("./path/to/proto_out".to_string()),
             dependencies: vec![Dependency {
-                name: DependencyName::new("dependency1".to_string()),
+                name: ModuleName::new("dependency1".to_string()),
                 coordinate: Coordinate {
                     forge: "github.com".to_string(),
                     organization: "org".to_string(),
@@ -660,11 +682,11 @@ mod tests {
                 url = "github.com/org/repo"
         "#;
         let expected = Descriptor {
-            name: "test_file".to_string(),
+            name: ModuleName::from("test_file"),
             description: Some("this is a description".to_string()),
             proto_out_dir: Some("./path/to/proto_out".to_string()),
             dependencies: vec![Dependency {
-                name: DependencyName::new("dependency1".to_string()),
+                name: ModuleName::new("dependency1".to_string()),
                 coordinate: Coordinate {
                     forge: "github.com".to_string(),
                     organization: "org".to_string(),
@@ -697,11 +719,11 @@ mod tests {
                 allow_policies = ["/foo/proto/file.proto", "/foo/other/*", "*/some/path/*"]
         "#;
         let expected = Descriptor {
-            name: "test_file".to_string(),
+            name: ModuleName::from("test_file"),
             description: Some("this is a description".to_string()),
             proto_out_dir: Some("./path/to/proto_out".to_string()),
             dependencies: vec![Dependency {
-                name: DependencyName::new("dependency1".to_string()),
+                name: ModuleName::new("dependency1".to_string()),
                 coordinate: Coordinate {
                     forge: "github.com".to_string(),
                     organization: "org".to_string(),
@@ -766,12 +788,12 @@ mod tests {
                 revision = "3.0.0"  
         "#;
         let expected = Descriptor {
-            name: "test_file".to_string(),
+            name: ModuleName::from("test_file"),
             description: None,
             proto_out_dir: Some("./path/to/proto_out".to_string()),
             dependencies: vec![
                 Dependency {
-                    name: DependencyName::new("dependency1".to_string()),
+                    name: ModuleName::new("dependency1".to_string()),
                     coordinate: Coordinate {
                         forge: "github.com".to_string(),
                         organization: "org".to_string(),
@@ -785,7 +807,7 @@ mod tests {
                     rules: Default::default(),
                 },
                 Dependency {
-                    name: DependencyName::new("dependency2".to_string()),
+                    name: ModuleName::new("dependency2".to_string()),
                     coordinate: Coordinate {
                         forge: "github.com".to_string(),
                         organization: "org".to_string(),
@@ -799,7 +821,7 @@ mod tests {
                     rules: Default::default(),
                 },
                 Dependency {
-                    name: DependencyName::new("dependency3".to_string()),
+                    name: ModuleName::new("dependency3".to_string()),
                     coordinate: Coordinate {
                         forge: "github.com".to_string(),
                         organization: "org".to_string(),
@@ -831,7 +853,7 @@ mod tests {
             proto_out_dir = "./path/to/proto_out"
         "#;
         let expected = Descriptor {
-            name: "test_file".to_string(),
+            name: ModuleName::from("test_file"),
             description: None,
             proto_out_dir: Some("./path/to/proto_out".to_string()),
             dependencies: vec![],

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -1,4 +1,5 @@
 pub mod lock;
+pub mod resolved;
 
 use derive_new::new;
 use regex::Regex;
@@ -217,12 +218,6 @@ pub struct RevisionSpecification {
     pub revision: Revision,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub branch: Option<String>,
-}
-
-impl RevisionSpecification {
-    pub fn is_default(&self) -> bool {
-        self.revision == Revision::Arbitrary && self.branch.is_none()
-    }
 }
 
 impl Display for RevisionSpecification {
@@ -620,11 +615,6 @@ mod tests {
 
     use super::*;
     use pretty_assertions::assert_eq;
-
-    #[test]
-    fn revision_specification_is_default() {
-        assert!(RevisionSpecification::default().is_default())
-    }
 
     #[test]
     fn load_valid_file_one_dep() {

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -16,7 +16,7 @@ use log::{debug, error};
 use std::{collections::BTreeSet, hash::Hash};
 use toml::{map::Map, Value};
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Ord, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Coordinate {
     pub forge: String,
     pub organization: String,

--- a/src/model/protofetch/resolved.rs
+++ b/src/model/protofetch/resolved.rs
@@ -1,18 +1,18 @@
 use std::collections::BTreeSet;
 
-use super::{Coordinate, DependencyName, RevisionSpecification, Rules};
+use super::{Coordinate, ModuleName, RevisionSpecification, Rules};
 
 pub struct ResolvedModule {
-    pub module_name: String,
+    pub module_name: ModuleName,
     pub dependencies: Vec<ResolvedDependency>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ResolvedDependency {
-    pub name: DependencyName,
+    pub name: ModuleName,
     pub commit_hash: String,
     pub coordinate: Coordinate,
     pub specification: RevisionSpecification,
     pub rules: Rules,
-    pub dependencies: BTreeSet<DependencyName>,
+    pub dependencies: BTreeSet<ModuleName>,
 }

--- a/src/model/protofetch/resolved.rs
+++ b/src/model/protofetch/resolved.rs
@@ -1,0 +1,18 @@
+use std::collections::BTreeSet;
+
+use super::{Coordinate, DependencyName, RevisionSpecification, Rules};
+
+pub struct ResolvedModule {
+    pub module_name: String,
+    pub dependencies: Vec<ResolvedDependency>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct ResolvedDependency {
+    pub name: DependencyName,
+    pub commit_hash: String,
+    pub coordinate: Coordinate,
+    pub specification: RevisionSpecification,
+    pub rules: Rules,
+    pub dependencies: BTreeSet<DependencyName>,
+}

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -735,13 +735,13 @@ mod tests {
         let expected = r#"module_name = "test"
 
 [[dependencies]]
-branch = "main"
-commit_hash = "hash2"
-forge = "example.com"
 name = "dep2"
+forge = "example.com"
 organization = "org"
 repository = "dep2"
 revision = "1.0.0"
+branch = "main"
+commit_hash = "hash2"
 "#;
         let lock_file = LockFile {
             module_name: ModuleName::from("test"),

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -735,15 +735,13 @@ mod tests {
         let expected = r#"module_name = "test"
 
 [[dependencies]]
+branch = "main"
 commit_hash = "hash2"
-name = "dep2"
-
-[dependencies.coordinate]
 forge = "example.com"
+name = "dep2"
 organization = "org"
 repository = "dep2"
-
-[dependencies.specification]
+revision = "1.0.0"
 "#;
         let lock_file = LockFile {
             module_name: ModuleName::from("test"),
@@ -751,7 +749,10 @@ repository = "dep2"
                 name: ModuleName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
                 coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
-                specification: RevisionSpecification::default(),
+                specification: RevisionSpecification {
+                    revision: Revision::pinned("1.0.0"),
+                    branch: Some("main".to_owned()),
+                },
             }],
         };
         let value_toml = toml::Value::try_from(lock_file).unwrap();

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -732,9 +732,7 @@ mod tests {
 
     #[test]
     fn generate_valid_lock_no_dep() {
-        let expected = r#"module_name = "test"
-
-[[dependencies]]
+        let expected = r#"[[dependencies]]
 name = "dep2"
 forge = "example.com"
 organization = "org"
@@ -744,7 +742,6 @@ branch = "main"
 commit_hash = "hash2"
 "#;
         let lock_file = LockFile {
-            module_name: ModuleName::from("test"),
             dependencies: vec![LockedDependency {
                 name: ModuleName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
@@ -763,7 +760,6 @@ commit_hash = "hash2"
     #[test]
     fn parse_valid_lock_no_dep() {
         let lock_file = LockFile {
-            module_name: ModuleName::from("test"),
             dependencies: vec![LockedDependency {
                 name: ModuleName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -425,10 +425,6 @@ fn path_strip_prefix(path: &Path, prefix: &Path) -> Result<PathBuf, ProtoError> 
 
 #[cfg(test)]
 mod tests {
-    use crate::model::protofetch::{
-        lock::{LockFile, LockedDependency},
-        *,
-    };
     use std::{
         collections::{BTreeSet, HashSet},
         path::{Path, PathBuf},
@@ -728,49 +724,5 @@ mod tests {
 
         let result = collect_all_root_dependencies(&lock_file);
         assert_eq!(result.len(), 4);
-    }
-
-    #[test]
-    fn generate_valid_lock_no_dep() {
-        let expected = r#"[[dependencies]]
-name = "dep2"
-forge = "example.com"
-organization = "org"
-repository = "dep2"
-revision = "1.0.0"
-branch = "main"
-commit_hash = "hash2"
-"#;
-        let lock_file = LockFile {
-            dependencies: vec![LockedDependency {
-                name: ModuleName::new("dep2".to_string()),
-                commit_hash: "hash2".to_string(),
-                coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
-                specification: RevisionSpecification {
-                    revision: Revision::pinned("1.0.0"),
-                    branch: Some("main".to_owned()),
-                },
-            }],
-        };
-        let value_toml = toml::Value::try_from(lock_file).unwrap();
-        let string_fmt = toml::to_string_pretty(&value_toml).unwrap();
-        assert_eq!(string_fmt, expected);
-    }
-
-    #[test]
-    fn parse_valid_lock_no_dep() {
-        let lock_file = LockFile {
-            dependencies: vec![LockedDependency {
-                name: ModuleName::new("dep2".to_string()),
-                commit_hash: "hash2".to_string(),
-                coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
-                specification: RevisionSpecification::default(),
-            }],
-        };
-        let value_toml = toml::Value::try_from(&lock_file).unwrap();
-        let string_fmt = toml::to_string_pretty(&value_toml).unwrap();
-        let new_lock_file = toml::from_str::<LockFile>(&string_fmt).unwrap();
-
-        assert_eq!(new_lock_file, lock_file);
     }
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,7 +1,7 @@
 use crate::{
     cache::RepositoryCache,
     model::protofetch::{
-        lock::{LockFile, LockedDependency},
+        resolved::{ResolvedDependency, ResolvedModule},
         AllowPolicies, DenyPolicies, DependencyName,
     },
 };
@@ -47,18 +47,18 @@ struct ProtoFileCanonicalMapping {
 /// lockfile: The lockfile that contains the dependencies to be copied
 pub fn copy_proto_files(
     cache: &impl RepositoryCache,
-    lockfile: &LockFile,
+    resolved: &ResolvedModule,
     proto_dir: &Path,
 ) -> Result<(), ProtoError> {
     info!(
         "Copying proto files from {} descriptor...",
-        lockfile.module_name
+        resolved.module_name
     );
     if !proto_dir.exists() {
         std::fs::create_dir_all(proto_dir)?;
     }
 
-    let deps = collect_all_root_dependencies(lockfile);
+    let deps = collect_all_root_dependencies(resolved);
 
     for dep in &deps {
         let dep_cache_dir = cache
@@ -67,7 +67,7 @@ pub fn copy_proto_files(
         let sources_to_copy: HashSet<ProtoFileMapping> = if !dep.rules.prune {
             copy_all_proto_files_for_dep(&dep_cache_dir, dep)?
         } else {
-            pruned_transitive_dependencies(cache, dep, lockfile)?
+            pruned_transitive_dependencies(cache, dep, resolved)?
         };
         let without_denied_files = sources_to_copy
             .into_iter()
@@ -82,7 +82,7 @@ pub fn copy_proto_files(
 /// Takes into account content_roots and Allow list rules
 fn copy_all_proto_files_for_dep(
     dep_cache_dir: &Path,
-    dep: &LockedDependency,
+    dep: &ResolvedDependency,
 ) -> Result<HashSet<ProtoFileMapping>, ProtoError> {
     let mut proto_mapping: Vec<ProtoFileMapping> = Vec::new();
     for file in dep_cache_dir.read_dir()? {
@@ -109,14 +109,14 @@ fn copy_all_proto_files_for_dep(
 /// until no new dependencies are found.
 fn pruned_transitive_dependencies(
     cache: &impl RepositoryCache,
-    dep: &LockedDependency,
-    lockfile: &LockFile,
+    dep: &ResolvedDependency,
+    lockfile: &ResolvedModule,
 ) -> Result<HashSet<ProtoFileMapping>, ProtoError> {
     fn process_mapping_file(
         cache: &impl RepositoryCache,
         mapping: ProtoFileCanonicalMapping,
-        dep: &LockedDependency,
-        lockfile: &LockFile,
+        dep: &ResolvedDependency,
+        lockfile: &ResolvedModule,
         visited: &mut HashSet<PathBuf>,
         deps: &mut HashSet<ProtoFileCanonicalMapping>,
     ) -> Result<(), ProtoError> {
@@ -135,8 +135,8 @@ fn pruned_transitive_dependencies(
     /// Looks in own repository and in transitive dependencies.
     fn inner_loop(
         cache: &impl RepositoryCache,
-        dep: &LockedDependency,
-        lockfile: &LockFile,
+        dep: &ResolvedDependency,
+        lockfile: &ResolvedModule,
         visited: &mut HashSet<PathBuf>,
         found_proto_deps: &mut HashSet<ProtoFileCanonicalMapping>,
     ) -> Result<(), ProtoError> {
@@ -191,7 +191,7 @@ fn pruned_transitive_dependencies(
     }
 
     // Select proto files for the transitive dependencies of this dependency
-    let t_deps: Vec<LockedDependency> = collect_transitive_dependencies(dep, lockfile);
+    let t_deps = collect_transitive_dependencies(dep, lockfile);
     for t_dep in t_deps {
         trace!(
             "Extracting transitive proto dependencies from {} for dependency {} ",
@@ -215,7 +215,7 @@ fn pruned_transitive_dependencies(
 fn copy_proto_sources_for_dep(
     proto_dir: &Path,
     dep_cache_dir: &Path,
-    dep: &LockedDependency,
+    dep: &ResolvedDependency,
     sources_to_copy: &HashSet<ProtoFileMapping>,
 ) -> Result<(), ProtoError> {
     debug!(
@@ -282,9 +282,9 @@ fn find_proto_files(dir: &Path) -> Result<Vec<PathBuf>, ProtoError> {
 
 ///From a dep and a lockfile, returns the transitive dependencies of the dep
 fn collect_transitive_dependencies(
-    dep: &LockedDependency,
-    lockfile: &LockFile,
-) -> Vec<LockedDependency> {
+    dep: &ResolvedDependency,
+    lockfile: &ResolvedModule,
+) -> Vec<ResolvedDependency> {
     lockfile
         .dependencies
         .clone()
@@ -296,16 +296,16 @@ fn collect_transitive_dependencies(
 /// Collects all root dependencies based on pruning rules and transitive dependencies
 /// This still has a limitation. At the moment.
 /// If a dependency is flagged as transitive it will only be included in transitive fetching which uses pruning.
-fn collect_all_root_dependencies(lockfile: &LockFile) -> Vec<LockedDependency> {
+fn collect_all_root_dependencies(resolved: &ResolvedModule) -> Vec<ResolvedDependency> {
     let mut deps = Vec::new();
 
-    for dep in &lockfile.dependencies {
-        let pruned = lockfile
+    for dep in &resolved.dependencies {
+        let pruned = resolved
             .dependencies
             .iter()
             .any(|iter_dep| iter_dep.dependencies.contains(&dep.name) && iter_dep.rules.prune);
 
-        let non_pruned = lockfile
+        let non_pruned = resolved
             .dependencies
             .iter()
             .any(|iter_dep| iter_dep.dependencies.contains(&dep.name) && !iter_dep.rules.prune);
@@ -321,7 +321,7 @@ fn collect_all_root_dependencies(lockfile: &LockFile) -> Vec<LockedDependency> {
 fn filtered_proto_files(
     proto_files: Vec<PathBuf>,
     dep_dir: &Path,
-    dep: &LockedDependency,
+    dep: &ResolvedDependency,
     should_filter: bool,
 ) -> Vec<ProtoFileCanonicalMapping> {
     proto_files
@@ -345,7 +345,7 @@ fn filtered_proto_files(
 fn canonical_mapping_for_proto_files(
     cache: &impl RepositoryCache,
     proto_files: &[PathBuf],
-    deps: &[LockedDependency],
+    deps: &[ResolvedDependency],
 ) -> Result<Vec<ProtoFileCanonicalMapping>, ProtoError> {
     let r: Result<Vec<ProtoFileCanonicalMapping>, ProtoError> = proto_files
         .iter()
@@ -359,7 +359,7 @@ fn canonical_mapping_for_proto_files(
 
 /// Remove content_root part of path if found
 fn zoom_in_content_root(
-    dep: &LockedDependency,
+    dep: &ResolvedDependency,
     proto_file_source: &Path,
 ) -> Result<PathBuf, ProtoError> {
     let mut proto_src = proto_file_source.to_path_buf();
@@ -383,7 +383,7 @@ fn zoom_in_content_root(
 
 fn zoom_out_content_root(
     cache: &impl RepositoryCache,
-    deps: &[LockedDependency],
+    deps: &[ResolvedDependency],
     proto_file_source: &Path,
 ) -> Result<PathBuf, ProtoError> {
     let mut proto_src = proto_file_source.to_path_buf();
@@ -425,7 +425,10 @@ fn path_strip_prefix(path: &Path, prefix: &Path) -> Result<PathBuf, ProtoError> 
 
 #[cfg(test)]
 mod tests {
-    use crate::model::protofetch::*;
+    use crate::model::protofetch::{
+        lock::{LockFile, LockedDependency},
+        *,
+    };
     use std::{
         collections::{BTreeSet, HashSet},
         path::{Path, PathBuf},
@@ -463,7 +466,7 @@ mod tests {
         let cache_dir = project_root::get_project_root()
             .unwrap()
             .join(Path::new("resources/cache/dep3/hash3"));
-        let lock_file = LockedDependency {
+        let lock_file = ResolvedDependency {
             name: DependencyName::new("dep3".to_string()),
             commit_hash: "hash3".to_string(),
             coordinate: Coordinate::from_url("example.com/org/dep3").unwrap(),
@@ -498,10 +501,10 @@ mod tests {
         let cache_dir = project_root::get_project_root()
             .unwrap()
             .join("resources/cache");
-        let lock_file = LockFile {
-            module_name: "test".to_string(),
+        let lock_file = ResolvedModule {
+            module_name: "test".to_owned(),
             dependencies: vec![
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1").unwrap(),
@@ -518,7 +521,7 @@ mod tests {
                         DenyPolicies::default(),
                     ),
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
@@ -573,10 +576,10 @@ mod tests {
 
     #[test]
     fn collect_transitive_dependencies_test() {
-        let lock_file = LockFile {
+        let lock_file = ResolvedModule {
             module_name: "test".to_string(),
             dependencies: vec![
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1").unwrap(),
@@ -587,7 +590,7 @@ mod tests {
                     ]),
                     rules: Rules::default(),
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
@@ -595,7 +598,7 @@ mod tests {
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep3".to_string()),
                     commit_hash: "hash3".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep3").unwrap(),
@@ -603,7 +606,7 @@ mod tests {
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep4".to_string()),
                     commit_hash: "hash4".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep4").unwrap(),
@@ -630,10 +633,10 @@ mod tests {
 
     #[test]
     fn collect_all_root_dependencies_() {
-        let lock_file = LockFile {
+        let lock_file = ResolvedModule {
             module_name: "test".to_string(),
             dependencies: vec![
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1").unwrap(),
@@ -641,7 +644,7 @@ mod tests {
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
@@ -649,7 +652,7 @@ mod tests {
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep3".to_string()),
                     commit_hash: "hash3".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep3").unwrap(),
@@ -666,10 +669,10 @@ mod tests {
 
     #[test]
     fn collect_all_root_dependencies_filtered() {
-        let lock_file = LockFile {
+        let lock_file = ResolvedModule {
             module_name: "test".to_string(),
             dependencies: vec![
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep1").unwrap(),
@@ -677,7 +680,7 @@ mod tests {
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::default(),
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
@@ -685,7 +688,7 @@ mod tests {
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep3".to_string()),
                     commit_hash: "hash3".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep3").unwrap(),
@@ -700,7 +703,7 @@ mod tests {
                         ..Default::default()
                     },
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep4".to_string()),
                     commit_hash: "hash4".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep4").unwrap(),
@@ -708,7 +711,7 @@ mod tests {
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
                 },
-                LockedDependency {
+                ResolvedDependency {
                     name: DependencyName::new("dep5".to_string()),
                     commit_hash: "hash5".to_string(),
                     coordinate: Coordinate::from_url("example.com/org/dep5").unwrap(),
@@ -742,9 +745,7 @@ repository = "dep2"
 [dependencies.name]
 value = "dep2"
 
-[dependencies.rules]
-prune = false
-transitive = false
+[dependencies.specification]
 "#;
         let lock_file = LockFile {
             module_name: "test".to_string(),
@@ -753,8 +754,6 @@ transitive = false
                 commit_hash: "hash2".to_string(),
                 coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                 specification: RevisionSpecification::default(),
-                dependencies: BTreeSet::new(),
-                rules: Rules::default(),
             }],
         };
         let value_toml = toml::Value::try_from(lock_file).unwrap();
@@ -771,8 +770,6 @@ transitive = false
                 commit_hash: "hash2".to_string(),
                 coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                 specification: RevisionSpecification::default(),
-                dependencies: BTreeSet::new(),
-                rules: Rules::default(),
             }],
         };
         let value_toml = toml::Value::try_from(&lock_file).unwrap();

--- a/src/resolver/git.rs
+++ b/src/resolver/git.rs
@@ -3,7 +3,7 @@ use crate::{
     model::protofetch::{Coordinate, DependencyName, RevisionSpecification},
 };
 
-use super::{ModuleResolver, ResolvedModule};
+use super::{CommitAndDescriptor, ModuleResolver};
 
 impl ModuleResolver for ProtofetchGitCache {
     fn resolve(
@@ -12,7 +12,7 @@ impl ModuleResolver for ProtofetchGitCache {
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
         name: &DependencyName,
-    ) -> anyhow::Result<ResolvedModule> {
+    ) -> anyhow::Result<CommitAndDescriptor> {
         let repository = self.repository(coordinate)?;
         let commit_hash = if let Some(commit_hash) = commit_hash {
             repository.fetch_commit(specification, commit_hash)?;
@@ -22,7 +22,7 @@ impl ModuleResolver for ProtofetchGitCache {
             repository.resolve_commit_hash(specification)?
         };
         let descriptor = repository.extract_descriptor(name, &commit_hash)?;
-        Ok(ResolvedModule {
+        Ok(CommitAndDescriptor {
             commit_hash,
             descriptor,
         })

--- a/src/resolver/git.rs
+++ b/src/resolver/git.rs
@@ -1,6 +1,6 @@
 use crate::{
     git::cache::ProtofetchGitCache,
-    model::protofetch::{Coordinate, DependencyName, RevisionSpecification},
+    model::protofetch::{Coordinate, ModuleName, RevisionSpecification},
 };
 
 use super::{CommitAndDescriptor, ModuleResolver};
@@ -11,7 +11,7 @@ impl ModuleResolver for ProtofetchGitCache {
         coordinate: &Coordinate,
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
-        name: &DependencyName,
+        name: &ModuleName,
     ) -> anyhow::Result<CommitAndDescriptor> {
         let repository = self.repository(coordinate)?;
         let commit_hash = if let Some(commit_hash) = commit_hash {

--- a/src/resolver/lock.rs
+++ b/src/resolver/lock.rs
@@ -3,7 +3,7 @@ use log::debug;
 
 use crate::model::protofetch::{lock::LockFile, Coordinate, DependencyName, RevisionSpecification};
 
-use super::{ModuleResolver, ResolvedModule};
+use super::{CommitAndDescriptor, ModuleResolver};
 
 pub struct LockFileModuleResolver<'a, R> {
     inner: R,
@@ -31,7 +31,7 @@ where
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
         name: &DependencyName,
-    ) -> anyhow::Result<ResolvedModule> {
+    ) -> anyhow::Result<CommitAndDescriptor> {
         let dependency = self.lock_file.dependencies.iter().find(|dependency| {
             &dependency.coordinate == coordinate && &dependency.specification == specification
         });

--- a/src/resolver/lock.rs
+++ b/src/resolver/lock.rs
@@ -1,7 +1,7 @@
 use anyhow::bail;
 use log::debug;
 
-use crate::model::protofetch::{lock::LockFile, Coordinate, DependencyName, RevisionSpecification};
+use crate::model::protofetch::{lock::LockFile, Coordinate, ModuleName, RevisionSpecification};
 
 use super::{CommitAndDescriptor, ModuleResolver};
 
@@ -30,7 +30,7 @@ where
         coordinate: &Coordinate,
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
-        name: &DependencyName,
+        name: &ModuleName,
     ) -> anyhow::Result<CommitAndDescriptor> {
         let dependency = self.lock_file.dependencies.iter().find(|dependency| {
             &dependency.coordinate == coordinate && &dependency.specification == specification

--- a/src/resolver/lock.rs
+++ b/src/resolver/lock.rs
@@ -1,7 +1,10 @@
 use anyhow::bail;
 use log::debug;
 
-use crate::model::protofetch::{lock::LockFile, Coordinate, ModuleName, RevisionSpecification};
+use crate::model::protofetch::{
+    lock::{LockFile, LockedCoordinate},
+    Coordinate, ModuleName, RevisionSpecification,
+};
 
 use super::{CommitAndDescriptor, ModuleResolver};
 
@@ -32,8 +35,9 @@ where
         commit_hash: Option<&str>,
         name: &ModuleName,
     ) -> anyhow::Result<CommitAndDescriptor> {
+        let locked_coordinate = LockedCoordinate::from(coordinate);
         let dependency = self.lock_file.dependencies.iter().find(|dependency| {
-            &dependency.coordinate == coordinate && &dependency.specification == specification
+            dependency.coordinate == locked_coordinate && &dependency.specification == specification
         });
         match dependency {
             Some(dependency) => {

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -12,11 +12,11 @@ pub trait ModuleResolver {
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
         name: &DependencyName,
-    ) -> anyhow::Result<ResolvedModule>;
+    ) -> anyhow::Result<CommitAndDescriptor>;
 }
 
 #[derive(Clone)]
-pub struct ResolvedModule {
+pub struct CommitAndDescriptor {
     pub commit_hash: String,
     pub descriptor: Descriptor,
 }
@@ -31,7 +31,7 @@ where
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
         name: &DependencyName,
-    ) -> anyhow::Result<ResolvedModule> {
+    ) -> anyhow::Result<CommitAndDescriptor> {
         T::resolve(self, coordinate, specification, commit_hash, name)
     }
 }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1,7 +1,7 @@
 mod git;
 mod lock;
 
-use crate::model::protofetch::{Coordinate, DependencyName, Descriptor, RevisionSpecification};
+use crate::model::protofetch::{Coordinate, Descriptor, ModuleName, RevisionSpecification};
 
 pub use lock::LockFileModuleResolver;
 
@@ -11,7 +11,7 @@ pub trait ModuleResolver {
         coordinate: &Coordinate,
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
-        name: &DependencyName,
+        name: &ModuleName,
     ) -> anyhow::Result<CommitAndDescriptor>;
 }
 
@@ -30,7 +30,7 @@ where
         coordinate: &Coordinate,
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
-        name: &DependencyName,
+        name: &ModuleName,
     ) -> anyhow::Result<CommitAndDescriptor> {
         T::resolve(self, coordinate, specification, commit_hash, name)
     }


### PR DESCRIPTION
We have already broken lockfile compatibility in both directions (because of https://github.com/coralogix/protofetch/pull/106 old protofetch versions work incorrectly with new lock files, and because of https://github.com/coralogix/protofetch/pull/110 new protofetch versions cannot work with old lock files). I think it's a good opportunity to cleanup the lock file structure.

1. Add a version to the lock files.
2. Remove unnecessary fields that we duplicating `protofetch.toml` fields.
3. Flatten lockfile structure to make it more human-friendly.
4. Write URLs to the lock file instead of `forge`/`organization`/`repository`. The latter is github-focused, as other git hosting providers may have a different URL scheme. I'm not changing the code that parses the URL, so we still won't be able to parse more complex URLs, but at least the lock file format will support them if needed.

Closes #30.