### PR TITLE
Make protocol optional and configurable locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,20 @@ revision = "a16f097eab6e64f2b711fd4b977e610791376223"
 transitive = true
 ```
 
-## HTTPS support
+## Git protocol
+
+Protofetch supports accessing Git repositories using `ssh` or `https`. By default, Protofetch uses `ssh`. You can configure the default Git protocol with the `PROTOFETCH_GIT_PROTOCOL` environment variable.
+
+It is also possible to set protocol in the `protofetch.toml`, but this should be only necessary if the Git server does not support both protocols. Otherwise, it is better to leave this field unset, to let users choose whichever protocol they prefer.
+
+### SSH support
+
+You need to have an SSH agent running, with your SSH key loaded:
+```sh
+ssh-add ~/.ssh/your-private-key
+```
+
+### HTTPS support
 
 If you want to use https you need to configure git to use a [credentials helper](https://git-scm.com/docs/gitcredentials).
 

--- a/src/api/builder.rs
+++ b/src/api/builder.rs
@@ -2,7 +2,10 @@ use std::{env, error::Error, path::PathBuf};
 
 use home::home_dir;
 
-use crate::{config::ProtofetchConfig, git::cache::ProtofetchGitCache, Protofetch};
+use crate::{
+    config::ProtofetchConfig, git::cache::ProtofetchGitCache, model::protofetch::Protocol,
+    Protofetch,
+};
 
 #[derive(Default)]
 pub struct ProtofetchBuilder {
@@ -81,7 +84,11 @@ impl ProtofetchBuilder {
 
         let git_config = git2::Config::open_default()?;
 
-        let cache = ProtofetchGitCache::new(cache_directory, git_config)?;
+        let cache = ProtofetchGitCache::new(
+            cache_directory,
+            git_config,
+            config.default_protocol.unwrap_or(Protocol::Ssh),
+        )?;
 
         Ok(Protofetch {
             cache,

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -42,7 +42,7 @@ pub fn lock(
         for dependency in dependencies {
             match resolved.get(&dependency.name) {
                 None => {
-                    log::info!("Resolving {:?}", dependency.coordinate);
+                    log::info!("Resolving {}", dependency.coordinate);
                     let mut resolved_module = resolver
                         .resolve(
                             &dependency.coordinate,
@@ -123,7 +123,7 @@ mod tests {
     use anyhow::anyhow;
 
     use crate::{
-        model::protofetch::{Coordinate, Protocol, Revision, RevisionSpecification, Rules},
+        model::protofetch::{Coordinate, Revision, RevisionSpecification, Rules},
         resolver::ResolvedModule,
     };
 
@@ -170,7 +170,7 @@ mod tests {
     }
 
     fn coordinate(name: &str) -> Coordinate {
-        Coordinate::from_url(&format!("example.com/org/{}", name), Protocol::Https).unwrap()
+        Coordinate::from_url(&format!("example.com/org/{}", name)).unwrap()
     }
 
     fn dependency(name: &str, revision: &str) -> Dependency {

--- a/src/model/protodep.rs
+++ b/src/model/protodep.rs
@@ -14,7 +14,7 @@ use toml::Value;
 #[serde(default)]
 pub struct Dependency {
     pub target: String,
-    pub protocol: String,
+    pub protocol: Option<String>,
     pub revision: String,
     pub subgroup: Option<String>,
     pub branch: Option<String>,
@@ -70,8 +70,11 @@ impl ProtodepDescriptor {
 
     pub fn into_proto_fetch(self) -> Result<Descriptor, ParseError> {
         fn convert_dependency(d: Dependency) -> Result<ProtofetchDependency, ParseError> {
-            let protocol: Protocol = Protocol::from_str(&d.protocol)?;
-            let coordinate = Coordinate::from_url(d.target.as_str(), protocol)?;
+            let protocol = match &d.protocol {
+                None => None,
+                Some(protocol) => Some(Protocol::from_str(protocol)?),
+            };
+            let coordinate = Coordinate::from_url_protocol(d.target.as_str(), protocol)?;
             let specification = RevisionSpecification {
                 revision: Revision::pinned(d.revision),
                 branch: d.branch,
@@ -128,7 +131,7 @@ proto_outdir = "./proto_out"
                 path: None,
                 ignores: vec![],
                 includes: vec![],
-                protocol: "ssh".to_string(),
+                protocol: Some("ssh".to_string()),
             }],
         };
 
@@ -154,7 +157,6 @@ proto_outdir = "./proto_out"
 
 [[dependencies]]
   target = "github.com/opensaasstudio/plasma2/protobuf"
-  protocol = "ssh"
   revision = "3.0.0"
 "#;
 
@@ -169,7 +171,7 @@ proto_outdir = "./proto_out"
                     path: None,
                     ignores: vec![],
                     includes: vec![],
-                    protocol: "ssh".to_string(),
+                    protocol: Some("ssh".to_string()),
                 },
                 Dependency {
                     target: "github.com/opensaasstudio/plasma1/protobuf".to_string(),
@@ -179,7 +181,7 @@ proto_outdir = "./proto_out"
                     path: None,
                     ignores: vec![],
                     includes: vec![],
-                    protocol: "https".to_string(),
+                    protocol: Some("https".to_string()),
                 },
                 Dependency {
                     target: "github.com/opensaasstudio/plasma2/protobuf".to_string(),
@@ -189,7 +191,7 @@ proto_outdir = "./proto_out"
                     path: None,
                     ignores: vec![],
                     includes: vec![],
-                    protocol: "ssh".to_string(),
+                    protocol: None,
                 },
             ],
         };

--- a/src/model/protofetch/lock.rs
+++ b/src/model/protofetch/lock.rs
@@ -55,7 +55,11 @@ mod tests {
             LockedDependency {
                 name: DependencyName::new("dep1".to_string()),
                 commit_hash: "hash1".to_string(),
-                coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https).unwrap(),
+                coordinate: Coordinate::from_url_protocol(
+                    "example.com/org/dep1",
+                    Some(Protocol::Https),
+                )
+                .unwrap(),
                 specification: RevisionSpecification {
                     revision: Revision::pinned("1.0.0"),
                     branch: Some("main".to_owned()),
@@ -75,7 +79,7 @@ mod tests {
             LockedDependency {
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
-                coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
+                coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                 specification: RevisionSpecification::default(),
                 dependencies: BTreeSet::new(),
                 rules: Rules::default(),

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -425,11 +425,17 @@ fn path_strip_prefix(path: &Path, prefix: &Path) -> Result<PathBuf, ProtoError> 
 
 #[cfg(test)]
 mod tests {
-    use crate::{model::protofetch::*, proto::*};
+    use crate::model::protofetch::*;
     use std::{
         collections::{BTreeSet, HashSet},
         path::{Path, PathBuf},
     };
+
+    use crate::model::protofetch::{
+        ContentRoot, Coordinate, FilePolicy, RevisionSpecification, Rules,
+    };
+
+    use super::*;
 
     use pretty_assertions::assert_eq;
 
@@ -460,7 +466,7 @@ mod tests {
         let lock_file = LockedDependency {
             name: DependencyName::new("dep3".to_string()),
             commit_hash: "hash3".to_string(),
-            coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https).unwrap(),
+            coordinate: Coordinate::from_url("example.com/org/dep3").unwrap(),
             specification: RevisionSpecification::default(),
             dependencies: BTreeSet::new(),
             rules: Rules::new(
@@ -498,8 +504,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep1").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::new(
@@ -516,8 +521,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -575,8 +579,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep1").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::from([
                         DependencyName::new("dep2".to_string()),
@@ -587,8 +590,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -596,8 +598,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep3".to_string()),
                     commit_hash: "hash3".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep3").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -605,8 +606,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep4".to_string()),
                     commit_hash: "hash4".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep4", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep4").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::new(
@@ -636,8 +636,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep1").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -645,8 +644,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -654,8 +652,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep3".to_string()),
                     commit_hash: "hash3".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep3").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -675,8 +672,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep1".to_string()),
                     commit_hash: "hash1".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep1", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep1").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::from([DependencyName::new("dep2".to_string())]),
                     rules: Rules::default(),
@@ -684,8 +680,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep2".to_string()),
                     commit_hash: "hash2".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -693,8 +688,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep3".to_string()),
                     commit_hash: "hash3".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep3", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep3").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::from([
                         DependencyName::new("dep2".to_string()),
@@ -709,8 +703,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep4".to_string()),
                     commit_hash: "hash4".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep4", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep4").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules::default(),
@@ -718,8 +711,7 @@ mod tests {
                 LockedDependency {
                     name: DependencyName::new("dep5".to_string()),
                     commit_hash: "hash5".to_string(),
-                    coordinate: Coordinate::from_url("example.com/org/dep5", Protocol::Https)
-                        .unwrap(),
+                    coordinate: Coordinate::from_url("example.com/org/dep5").unwrap(),
                     specification: RevisionSpecification::default(),
                     dependencies: BTreeSet::new(),
                     rules: Rules {
@@ -745,7 +737,6 @@ commit_hash = "hash2"
 [dependencies.coordinate]
 forge = "example.com"
 organization = "org"
-protocol = "https"
 repository = "dep2"
 
 [dependencies.name]
@@ -760,7 +751,7 @@ transitive = false
             dependencies: vec![LockedDependency {
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
-                coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
+                coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                 specification: RevisionSpecification::default(),
                 dependencies: BTreeSet::new(),
                 rules: Rules::default(),
@@ -778,7 +769,7 @@ transitive = false
             dependencies: vec![LockedDependency {
                 name: DependencyName::new("dep2".to_string()),
                 commit_hash: "hash2".to_string(),
-                coordinate: Coordinate::from_url("example.com/org/dep2", Protocol::Https).unwrap(),
+                coordinate: Coordinate::from_url("example.com/org/dep2").unwrap(),
                 specification: RevisionSpecification::default(),
                 dependencies: BTreeSet::new(),
                 rules: Rules::default(),


### PR DESCRIPTION
Most of the time git protocol should be a local decision, not part of the module descriptor. This PR makes it optional, and allows to configure the default protocol locally (for now only with an environment variable).

Closes #102