### PR TITLE
Use a more standard cache directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -99,9 +99,14 @@ fn config_dir() -> Option<PathBuf> {
 }
 
 fn default_cache_dir() -> anyhow::Result<PathBuf> {
+    if let Ok(path) = std::env::var("XDG_CACHE_HOME") {
+        let mut path = PathBuf::from(path);
+        path.push("protofetch");
+        return Ok(path);
+    }
     if let Some(mut path) = home::home_dir() {
-        path.push(".protofetch");
-        path.push("cache");
+        path.push(".cache");
+        path.push("protofetch");
         return Ok(path);
     }
     bail!("Could not find home dir. Please define $HOME env variable.")


### PR DESCRIPTION
`~/.cache/protofetch` instead of `~/.protofetch/cache`. This is more standard, and also makes it less confusing — otherwise people may expect to find a config file in `~/.protofetch/...`, which is not the case. We will advise users to delete the old cache directory.

It makes sense to do it now, because we have already broken the lockfile compatibility, so users are likely to update.