### PR TITLE
Update rust-toolchain.toml channel to 1.76.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.70.0"
+channel = "1.76.0"


### PR DESCRIPTION
This updates the rust version to `1.76.0`