### PR TITLE
Replace binary-install with simple-binary-install

### DIFF
--- a/.github/npm/.gitignore
+++ b/.github/npm/.gitignore
@@ -1,0 +1,2 @@
+/package-lock.json
+/node_modules/

--- a/.github/npm/getBinary.js
+++ b/.github/npm/getBinary.js
@@ -1,5 +1,6 @@
-const { Binary } = require('binary-install');
-const os = require('os');
+import { Binary } from 'simple-binary-install';
+import * as os from 'os';
+import * as fs from 'fs';
 
 function getPlatform() {
 	const type = os.type();
@@ -28,13 +29,11 @@ function getPlatform() {
 	throw new Error(`Unsupported platform: ${type} ${arch}. Please create an issue at https://github.com/coralogix/protofetch/issues`);
 }
 
-function getBinary() {
+export function getBinary() {
 	const platform = getPlatform();
-	const version = require('./package.json').version;
+	const { version } = JSON.parse(fs.readFileSync('./package.json'));
 	const url = `https://github.com/coralogix/protofetch/releases/download/v${version}/protofetch_${platform}.tar.gz`;
 	const name = 'protofetch';
 
 	return new Binary(name, url)
 }
-
-module.exports = getBinary;

--- a/.github/npm/package.json
+++ b/.github/npm/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/coralogix/protofetch.git",
   "homepage": "https://github.com/coralogix/protofetch",
   "license": "Apache-2.0",
+  "type": "module",
   "bin": {
     "protofetch": "run.js"
   },
@@ -12,11 +13,7 @@
     "postinstall": "node scripts.js install"
   },
   "dependencies": {
-    "binary-install": "^1.0.1"
-  },
-  "devDependencies": {
-    "ncp": "^2.0.0",
-    "vuepress": "^1.9.7"
+    "simple-binary-install": "^0.2.1"
   },
   "keywords": [
     "proto",

--- a/.github/npm/run.js
+++ b/.github/npm/run.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-const getBinary = require('./getBinary');
+import { getBinary } from './getBinary.js';
 
-const binary = getBinary();
-binary.run();
+getBinary().run();

--- a/.github/npm/scripts.js
+++ b/.github/npm/scripts.js
@@ -1,13 +1,5 @@
-function getBinary({ fatal }) {
-	try {
-		return require('./getBinary')();
-	} catch (err) {
-		if (fatal) throw err;
-	}
-}
+import { getBinary } from './getBinary.js';
 
 if (process.argv.includes('install')) {
-	const binary = getBinary({ fatal: true });
-	if (binary) binary.install();
+	getBinary().install();
 }
-


### PR DESCRIPTION
`binary-install` has open CVEs, and `simple-binary-install` seems to do the same thing, but with fewer dependencies.