### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.4](https://github.com/coralogix/protofetch/compare/v0.1.3...v0.1.4) - 2024-05-22
+
+### Other
+- Prevent concurrent cache access ([#135](https://github.com/coralogix/protofetch/pull/135))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "A source dependency management tool for Protobuf."


### PR DESCRIPTION
## 🤖 New release
* `protofetch`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/coralogix/protofetch/compare/v0.1.3...v0.1.4) - 2024-05-22

### Other
- Prevent concurrent cache access ([#135](https://github.com/coralogix/protofetch/pull/135))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).