### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/coralogix/protofetch/compare/v0.1.4...v0.1.5) - 2024-06-27
+
+### Other
+- Cache lock improvements ([#140](https://github.com/coralogix/protofetch/pull/140))
+
 ## [0.1.4](https://github.com/coralogix/protofetch/compare/v0.1.3...v0.1.4) - 2024-05-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,7 +894,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "Apache-2.0"
 description = "A source dependency management tool for Protobuf."


### PR DESCRIPTION
## 🤖 New release
* `protofetch`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/coralogix/protofetch/compare/v0.1.4...v0.1.5) - 2024-06-27

### Other
- Cache lock improvements ([#140](https://github.com/coralogix/protofetch/pull/140))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).