### PR TITLE
Fetch optimizations

### DIFF
--- a/src/git/cache.rs
+++ b/src/git/cache.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use git2::{
-    cert::Cert, CertificateCheckStatus, Config, Cred, CredentialType, FetchOptions,
+    cert::Cert, AutotagOption, CertificateCheckStatus, Config, Cred, CredentialType, FetchOptions,
     RemoteCallbacks, Repository,
 };
 use gix_lock::Marker;
@@ -185,7 +185,7 @@ impl ProtofetchGitCache {
         let mut fetch_options = FetchOptions::new();
         fetch_options
             .remote_callbacks(callbacks)
-            .download_tags(git2::AutotagOption::All);
+            .download_tags(AutotagOption::None);
 
         Ok(fetch_options)
     }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, str::Utf8Error};
 
 use crate::model::protofetch::{Descriptor, ModuleName, Revision, RevisionSpecification};
-use git2::{Oid, Repository, ResetType};
+use git2::{Oid, Repository, ResetType, WorktreeAddOptions};
 use log::{debug, warn};
 use thiserror::Error;
 
@@ -40,11 +40,20 @@ pub enum ProtoRepoError {
 pub struct ProtoGitRepository<'a> {
     cache: &'a ProtofetchGitCache,
     git_repo: Repository,
+    origin: String,
 }
 
 impl<'a> ProtoGitRepository<'a> {
-    pub fn new(cache: &'a ProtofetchGitCache, git_repo: Repository) -> ProtoGitRepository {
-        ProtoGitRepository { cache, git_repo }
+    pub fn new(
+        cache: &'a ProtofetchGitCache,
+        git_repo: Repository,
+        origin: String,
+    ) -> ProtoGitRepository {
+        ProtoGitRepository {
+            cache,
+            git_repo,
+            origin,
+        }
     }
 
     pub fn fetch(&self, _specification: &RevisionSpecification) -> anyhow::Result<()> {
@@ -54,6 +63,8 @@ impl<'a> ProtoGitRepository<'a> {
             .refspecs()
             .filter_map(|refspec| refspec.str().map(|s| s.to_string()))
             .collect();
+
+        debug!("Fetching everything from {}", self.origin);
         remote.fetch(&refspecs, Some(&mut self.cache.fetch_options()?), None)?;
         Ok(())
     }
@@ -69,6 +80,7 @@ impl<'a> ProtoGitRepository<'a> {
         }
         let mut remote = self.git_repo.find_remote("origin")?;
 
+        debug!("Fetching {} from {}", commit_hash, self.origin);
         if let Err(error) =
             remote.fetch(&[commit_hash], Some(&mut self.cache.fetch_options()?), None)
         {
@@ -212,8 +224,18 @@ impl<'a> ProtoGitRepository<'a> {
                     worktree_path.to_string_lossy()
                 );
 
+                // We need to create a branch-like reference to be able to create a worktree
+                let reference = self.git_repo.reference(
+                    &format!("refs/heads/{}", commit_hash),
+                    self.git_repo.revparse_single(commit_hash)?.id(),
+                    true,
+                    "",
+                )?;
+
+                let mut options = WorktreeAddOptions::new();
+                options.reference(Some(&reference));
                 self.git_repo
-                    .worktree(worktree_name, &worktree_path, None)?;
+                    .worktree(worktree_name, &worktree_path, Some(&options))?;
             }
         };
 


### PR DESCRIPTION
- When we know the commit hash, only fetch this commit (and its ancestors)
- When we only have a revision/branch, only fetch the relevant refs (and their ancestors).

This makes fetches significantly faster. For example, for googleapis/googleapis, it decreases the time from 1m20s to about 30s.

An even bigger improvement would be to
1. Shallow fetch. This is supported by libgit2 but I couldn't make it work.
2. Sparse checkout. This is not even supported by libgit2.

https://github.com/coralogix/protofetch/issues/137