### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/coralogix/protofetch/compare/v0.1.6...v0.1.7) - 2024-07-29
+
+### Other
+- Fix nix flake build and check this on CI ([#145](https://github.com/coralogix/protofetch/pull/145))
+- Update dependencies ([#144](https://github.com/coralogix/protofetch/pull/144))
+
 ## [0.1.6](https://github.com/coralogix/protofetch/compare/v0.1.5...v0.1.6) - 2024-07-02
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 rust-version = "1.74"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `protofetch`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/coralogix/protofetch/compare/v0.1.6...v0.1.7) - 2024-07-29

### Other
- Fix nix flake build and check this on CI ([#145](https://github.com/coralogix/protofetch/pull/145))
- Update dependencies ([#144](https://github.com/coralogix/protofetch/pull/144))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).