### PR TITLE
Update upload/download artifact actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
             cross: false
             ext:
           - rust: x86_64-apple-darwin
-            runner: macos-12
+            runner: macos-13
             # We use gtar to make sure compressed files are not detected as sparse
             tar: gtar
             cross: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,9 +152,9 @@ jobs:
           ${{ matrix.target.tar }} -czvf protofetch_${{ matrix.target.rust }}.tar.gz bin/protofetch${{ matrix.target.ext }}
 
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: packages
+          name: package-${{ matrix.target.rust }}
           path: protofetch_${{ matrix.target.rust }}.tar.gz
 
   release:
@@ -183,9 +183,9 @@ jobs:
           npm publish .github/npm
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: packages
+          pattern: package-*
 
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The v3 actions have been deprecated and don't even work anymore.
Also, update the intel-based macOS runner, as macos-12 is no longer supported either.