### PR TITLE
chore: release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/coralogix/protofetch/compare/v0.1.9...v0.1.10) - 2025-02-25
+
+### Other
+- Fix packages not being attached to the release ([#155](https://github.com/coralogix/protofetch/pull/155))
+
 ## [0.1.9](https://github.com/coralogix/protofetch/compare/v0.1.8...v0.1.9) - 2025-02-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `protofetch`: 0.1.9 -> 0.1.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

[0.1.10](https://github.com/coralogix/protofetch/compare/v0.1.9...v0.1.10) - 2025-02-25

- Fix packages not being attached to the release ([#155](https://github.com/coralogix/protofetch/pull/155)) </blockquote>

</p></details>