### PR TITLE
chore: release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/coralogix/protofetch/compare/v0.1.10...v0.1.11) - 2025-02-27
+
+### Other
+
+- Fix cache directory lock ([#157](https://github.com/coralogix/protofetch/pull/157))
+
 ## [0.1.10](https://github.com/coralogix/protofetch/compare/v0.1.9...v0.1.10) - 2025-02-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `protofetch`: 0.1.10 -> 0.1.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.11](https://github.com/coralogix/protofetch/compare/v0.1.10...v0.1.11) - 2025-02-27

### Other

- Fix cache directory lock ([#157](https://github.com/coralogix/protofetch/pull/157))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).