### PR TITLE
Preserve dependencies order

### DIFF
--- a/src/model/protodep.rs
+++ b/src/model/protodep.rs
@@ -7,8 +7,8 @@ use crate::model::{
 };
 use log::{debug, error};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::Path, str::FromStr};
-use toml::Value;
+use std::{path::Path, str::FromStr};
+use toml::{map::Map, Value};
 
 #[derive(PartialEq, Eq, Hash, Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(default)]
@@ -46,7 +46,7 @@ impl ProtodepDescriptor {
     }
 
     pub fn from_toml_str(data: &str) -> Result<ProtodepDescriptor, ParseError> {
-        let mut toml_value = toml::from_str::<HashMap<String, Value>>(data)?;
+        let mut toml_value = toml::from_str::<Map<String, Value>>(data)?;
 
         let proto_out_dir = toml_value
             .remove("proto_outdir")

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -4,7 +4,6 @@ pub mod resolved;
 use regex_lite::Regex;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
-    collections::HashMap,
     fmt::{Debug, Display, Write},
     path::{Path, PathBuf},
     str::FromStr,
@@ -472,7 +471,7 @@ impl Descriptor {
     }
 
     pub fn from_toml_str(data: &str) -> Result<Descriptor, ParseError> {
-        let mut toml_value = toml::from_str::<HashMap<String, Value>>(data)?;
+        let mut toml_value = toml::from_str::<Map<String, Value>>(data)?;
 
         let name = toml_value
             .remove("name")


### PR DESCRIPTION
When the same dependency exists multiple times in the dependency tree with slightly different attributes, we prefer the one closer to the root, but if they appear on the same level, the order matters (the first one wins).

The PR makes protofetch process dependencies in the order they are defined in protofetch.toml, which should make resolution reproducible.