### PR TITLE
chore: release v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/coralogix/protofetch/compare/v0.1.11...v0.1.12) - 2025-10-21
+
+### Other
+
+- Preserve dependencies order ([#166](https://github.com/coralogix/protofetch/pull/166))
+- Delete apple_sdk.frameworks.Security ([#165](https://github.com/coralogix/protofetch/pull/165))
+- Add to the readme an example of subtree checkout ([#164](https://github.com/coralogix/protofetch/pull/164))
+- Include content_roots in README ([#163](https://github.com/coralogix/protofetch/pull/163))
+- Upgrade dependencies and tooling ([#160](https://github.com/coralogix/protofetch/pull/160))
+- fix typo (#159)
+
 ## [0.1.11](https://github.com/coralogix/protofetch/compare/v0.1.10...v0.1.11) - 2025-02-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `protofetch`: 0.1.11 -> 0.1.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.12](https://github.com/coralogix/protofetch/compare/v0.1.11...v0.1.12) - 2025-10-21

### Other

- Preserve dependencies order ([#166](https://github.com/coralogix/protofetch/pull/166))
- Delete apple_sdk.frameworks.Security ([#165](https://github.com/coralogix/protofetch/pull/165))
- Add to the readme an example of subtree checkout ([#164](https://github.com/coralogix/protofetch/pull/164))
- Include content_roots in README ([#163](https://github.com/coralogix/protofetch/pull/163))
- Upgrade dependencies and tooling ([#160](https://github.com/coralogix/protofetch/pull/160))
- fix typo (#159)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).