### PR TITLE
refactor: improve npm package code

### DIFF
--- a/.github/npm/getBinary.js
+++ b/.github/npm/getBinary.js
@@ -1,38 +1,24 @@
-import fetch from 'node-fetch';
-import { mkdirSync, chmodSync, existsSync, readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import { pipeline } from 'stream/promises';
+import { mkdirSync, chmodSync, existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import * as tar from 'tar';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+function isPlatform(platform, arch) {
+	return process.platform === platform && process.arch === arch;
+}
+
 function getPlatform() {
-	const type = process.platform;
-	const arch = process.arch;
+	if (isPlatform('win32', 'x64')) return 'x86_64-pc-windows-msvc';
+	if (isPlatform('linux', 'x64')) return 'x86_64-unknown-linux-musl';
+	if (isPlatform('linux', 'arm64')) return 'aarch64-unknown-linux-musl';
+	if (isPlatform('darwin', 'x64')) return 'x86_64-apple-darwin';
+	if (isPlatform('darwin', 'arm64')) return 'aarch64-apple-darwin';
 
-	if (type === 'win32' && arch === 'x64') {
-		return 'x86_64-pc-windows-msvc';
-	}
-
-	if (type === 'linux' && arch === 'x64') {
-		return 'x86_64-unknown-linux-musl';
-	}
-
-	if (type === 'linux' && arch === 'arm64') {
-		return 'aarch64-unknown-linux-musl';
-	}
-
-	if (type === 'darwin' && arch === 'x64') {
-		return 'x86_64-apple-darwin';
-	}
-
-	if (type === 'darwin' && arch === 'arm64') {
-		return 'aarch64-apple-darwin';
-	}
-
-	throw new Error(`Unsupported platform: ${type} ${arch}. Please create an issue at https://github.com/coralogix/protofetch/issues`);
+	throw new Error(`Unsupported platform: ${process.platform} ${process.arch}. Please create an issue at https://github.com/coralogix/protofetch/issues`);
 }
 
 function getVersion() {
@@ -63,8 +49,7 @@ async function downloadBinary(options = {}) {
 	for (let attempt = 1; attempt <= 3; attempt++) {
 		try {
 			const response = await fetch(url, {
-				redirect: 'follow',
-				timeout: 60000
+				redirect: 'follow'
 			});
 
 			if (!response.ok) {

--- a/.github/npm/package.json
+++ b/.github/npm/package.json
@@ -12,8 +12,10 @@
   "scripts": {
     "postinstall": "node scripts.js install"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
-    "node-fetch": "^3.3.2",
     "tar": "^7.4.3"
   },
   "keywords": [

--- a/.github/npm/run.js
+++ b/.github/npm/run.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { spawn } from 'child_process';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/.github/npm/scripts.js
+++ b/.github/npm/scripts.js
@@ -1,21 +1,30 @@
+import { parseArgs } from 'node:util';
 import { downloadBinary } from './getBinary.js';
 
+function isLocalhost(hostname) {
+	return hostname === 'localhost' || hostname === '127.0.0.1';
+}
+
 if (process.argv.includes('install')) {
-	// Check for --url argument for testing (only localhost allowed for security)
-	const urlArg = process.argv.find(arg => arg.startsWith('--url='));
+	const { values } = parseArgs({
+		options: {
+			url: {
+				type: 'string'
+			}
+		},
+		strict: false
+	});
+
 	let url = null;
 
-	if (urlArg) {
-		const providedUrl = urlArg.split('=')[1];
+	if (values.url) {
 		try {
-			const parsedUrl = new URL(providedUrl);
-			// Only allow localhost URLs for testing
-			if (parsedUrl.hostname === 'localhost' || parsedUrl.hostname === '127.0.0.1') {
-				url = providedUrl;
-			} else {
+			const parsedUrl = new URL(values.url);
+			if (!isLocalhost(parsedUrl.hostname)) {
 				console.error('Error: --url parameter only allows localhost URLs for security reasons');
 				process.exit(1);
 			}
+			url = values.url;
 		} catch (error) {
 			console.error('Error: Invalid URL provided to --url parameter');
 			process.exit(1);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,12 +179,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -204,7 +204,6 @@ jobs:
         shell: bash
         run: |
           cd artifacts
-          # Start HTTP server in background
           python3 -m http.server 8000 &
           echo $! > /tmp/http_server.pid
           sleep 2


### PR DESCRIPTION
- Update Node.js version from 20 to 22 in CI
- Update pnpm version from 8 to 10 in CI
- Replace node-fetch with built-in fetch API
- Prefix all Node.js core modules with 'node:' protocol
- Extract platform/arch checks into isPlatform() utility function
- Use parseArgs() for CLI argument parsing
- Extract localhost validation into isLocalhost() function
- Remove node-fetch dependency from package.json