### PR TITLE
chore: release v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15](https://github.com/coralogix/protofetch/compare/v0.1.14...v0.1.15) - 2025-11-17
+
+### Other
+
+- Do not try same credentials over and over ([#178](https://github.com/coralogix/protofetch/pull/178))
+
 ## [0.1.14](https://github.com/coralogix/protofetch/compare/v0.1.13...v0.1.14) - 2025-11-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `protofetch`: 0.1.14 -> 0.1.15 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.15](https://github.com/coralogix/protofetch/compare/v0.1.14...v0.1.15) - 2025-11-17

### Other

- Do not try same credentials over and over ([#178](https://github.com/coralogix/protofetch/pull/178))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).