### PR TITLE
Remove protobuf system deps from transitive dependencies and fix worktree creation logging

### DIFF
--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -218,7 +218,7 @@ impl ProtoGitRepository<'_> {
                         wanted_path: worktree_path.to_str().unwrap_or("").to_string(),
                     });
                 } else {
-                    log::info!(
+                    log::debug!(
                         "Found existing worktree for {} at {}.",
                         name,
                         canonical_wanted_path.to_string_lossy()


### PR DESCRIPTION
* Protobuf files are system dependencies, and are not managed by protofetch: we should not try to copy them over to the output directory, because they're not found in the protofetch cache, and therefore we will always get a "no such file or directory" error.
* I levelled the worktree existence log down to debug, because when we have transitive dependencies and pruning, standard output will be cluttered.