### PR TITLE
chore: Replace macos-13 github runner with macos-15

### DIFF
--- a/.github/npm/src/getBinary.js
+++ b/.github/npm/src/getBinary.js
@@ -91,7 +91,7 @@ async function downloadBinary(options = {}) {
 		}
 	}
 
-	throw new Error(`Failed to download protofetch after 3 attempts: ${lastError.message}`);
+	throw new Error(`Failed to download protofetch after 3 attempts`, { cause: lastError });
 }
 
 export { downloadBinary };

--- a/.github/npm/src/scripts.js
+++ b/.github/npm/src/scripts.js
@@ -37,7 +37,7 @@ if (process.argv.includes('install')) {
 			process.exit(0);
 		})
 		.catch((error) => {
-			console.error('Installation failed:', error.message);
+			console.error('Installation failed:', error);
 			process.exit(1);
 		});
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: cargo test
 
   versions:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       - uses: taiki-e/install-action@v2
         with:
@@ -65,16 +65,16 @@ jobs:
         run: cargo minimal-versions check --rust-version --features vendored-openssl,vendored-libgit2
 
   semver:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
 
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
-  
+
   flake:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -106,24 +106,24 @@ jobs:
             runner: ubuntu-latest
             tar: tar
             cross: true
-            ext:
+            ext: ''
           - rust: x86_64-unknown-linux-musl
             runner: ubuntu-latest
             tar: tar
             cross: true
-            ext:
+            ext: ''
           - rust: aarch64-apple-darwin
             runner: macos-14
             # We use gtar to make sure compressed files are not detected as sparse
             tar: gtar
             cross: false
-            ext:
+            ext: ''
           - rust: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-15-intel
             # We use gtar to make sure compressed files are not detected as sparse
             tar: gtar
             cross: false
-            ext:
+            ext: ''
           - rust: x86_64-pc-windows-msvc
             runner: windows-latest
             tar: tar
@@ -167,7 +167,7 @@ jobs:
             platform: x86_64-unknown-linux-musl
           - runner: macos-14
             platform: aarch64-apple-darwin
-          - runner: macos-13
+          - runner: macos-15-intel
             platform: x86_64-apple-darwin
           - runner: windows-latest
             platform: x86_64-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,13 +199,10 @@ jobs:
           node .github/npm/prepare-package.js --package coralogix-protofetch --version 0.0.0-test
 
       - name: Start HTTP server
-        shell: bash
-        run: |
-          cd artifacts
-          python3 -m http.server 8000 &
-          echo $! > /tmp/http_server.pid
-          sleep 2
-          echo "HTTP server started on port 8000"
+        uses: Eun/http-server-action@v1
+        with:
+          port: 8000
+          directory: artifacts
 
       - name: Test npm installation
         shell: bash
@@ -244,14 +241,6 @@ jobs:
             ./bin/protofetch.exe --version
           else
             ./bin/protofetch --version
-          fi
-
-      - name: Stop HTTP server
-        if: always()
-        shell: bash
-        run: |
-          if [ -f /tmp/http_server.pid ]; then
-            kill $(cat /tmp/http_server.pid) || true
           fi
 
   release:


### PR DESCRIPTION
macOS 13 runners have been deprecated: https://github.com/actions/runner-images/issues/13046

The build was failing with an unhelpful error "fetch failed". I improved error logging ([example](https://github.com/coralogix/protofetch/actions/runs/20776625858/job/59665172896)), and replaced `python3 -m http.server` with a specialized github action which seems to be more reliable.