### PR TITLE
chore: Keep directory tree traversal in one place

### DIFF
--- a/src/proto.rs
+++ b/src/proto.rs
@@ -84,25 +84,22 @@ fn copy_all_proto_files_for_dep(
     dep_cache_dir: &Path,
     dep: &ResolvedDependency,
 ) -> Result<HashSet<ProtoFileMapping>, ProtoError> {
-    let mut proto_mapping: Vec<ProtoFileMapping> = Vec::new();
-    for file in dep_cache_dir.read_dir()? {
-        let path = file?.path();
-        let proto_files = find_proto_files(path.as_path())?;
-        for proto_file_source in proto_files {
-            let proto_src = path_strip_prefix(&proto_file_source, dep_cache_dir)?;
-            let proto_package_path = zoom_in_content_root(dep, &proto_src)?;
-            if !AllowPolicies::should_allow_file(&dep.rules.allow_policies, &proto_package_path) {
-                trace!(
-                    "Filtering out proto file {} based on allow_policies rules.",
-                    &proto_file_source.to_string_lossy()
-                );
-                continue;
-            }
-            proto_mapping.push(ProtoFileMapping {
-                from: proto_src,
-                to: proto_package_path,
-            });
+    let proto_files = find_proto_files(dep_cache_dir)?;
+    let mut proto_mapping = HashSet::with_capacity(proto_files.len());
+    for proto_file_source in proto_files {
+        let proto_src = path_strip_prefix(&proto_file_source, dep_cache_dir)?;
+        let proto_package_path = zoom_in_content_root(dep, &proto_src)?;
+        if !AllowPolicies::should_allow_file(&dep.rules.allow_policies, &proto_package_path) {
+            trace!(
+                "Filtering out proto file {} based on allow_policies rules.",
+                &proto_file_source.to_string_lossy()
+            );
+            continue;
         }
+        proto_mapping.insert(ProtoFileMapping {
+            from: proto_src,
+            to: proto_package_path,
+        });
     }
     Ok(proto_mapping.into_iter().collect())
 }
@@ -146,24 +143,21 @@ fn pruned_transitive_dependencies(
         let dep_dir = cache
             .create_worktree(&dep.coordinate, &dep.commit_hash, &dep.name)
             .map_err(ProtoError::Cache)?;
-        for dir in dep_dir.read_dir()? {
-            let proto_files = find_proto_files(&dir?.path())?;
-            let filtered_mapping = filtered_proto_files(proto_files, &dep_dir, dep, false)
-                .into_iter()
-                .collect();
-            let file_dependencies: HashSet<ProtoFileCanonicalMapping> = found_proto_deps
-                .intersection(&filtered_mapping)
-                .cloned()
-                .collect();
-            let file_dependencies_not_visited: HashSet<ProtoFileCanonicalMapping> =
-                file_dependencies
-                    .into_iter()
-                    .filter(|p| !visited.contains(&p.package_path))
-                    .collect();
-            for mapping in file_dependencies_not_visited {
-                process_mapping_file(cache, mapping, dep, lockfile, visited, found_proto_deps)?;
-                inner_loop(cache, dep, lockfile, visited, found_proto_deps)?;
-            }
+        let proto_files = find_proto_files(&dep_dir)?;
+        let filtered_mapping = filtered_proto_files(proto_files, &dep_dir, dep, false)
+            .into_iter()
+            .collect();
+        let file_dependencies: HashSet<ProtoFileCanonicalMapping> = found_proto_deps
+            .intersection(&filtered_mapping)
+            .cloned()
+            .collect();
+        let file_dependencies_not_visited: HashSet<ProtoFileCanonicalMapping> = file_dependencies
+            .into_iter()
+            .filter(|p| !visited.contains(&p.package_path))
+            .collect();
+        for mapping in file_dependencies_not_visited {
+            process_mapping_file(cache, mapping, dep, lockfile, visited, found_proto_deps)?;
+            inner_loop(cache, dep, lockfile, visited, found_proto_deps)?;
         }
         Ok(())
     }
@@ -176,21 +170,19 @@ fn pruned_transitive_dependencies(
     let dep_dir = cache
         .create_worktree(&dep.coordinate, &dep.commit_hash, &dep.name)
         .map_err(ProtoError::Cache)?;
-    for dir in dep_dir.read_dir()? {
-        let proto_files = find_proto_files(&dir?.path())?;
-        let filtered_mapping = filtered_proto_files(proto_files, &dep_dir, dep, true);
-        trace!("Filtered size {:?}.", &filtered_mapping.len());
-        for mapping in filtered_mapping {
-            process_mapping_file(
-                cache,
-                mapping,
-                dep,
-                lockfile,
-                &mut visited,
-                &mut found_proto_deps,
-            )?;
-            inner_loop(cache, dep, lockfile, &mut visited, &mut found_proto_deps)?;
-        }
+    let proto_files = find_proto_files(&dep_dir)?;
+    let filtered_mapping = filtered_proto_files(proto_files, &dep_dir, dep, true);
+    trace!("Filtered size {:?}.", &filtered_mapping.len());
+    for mapping in filtered_mapping {
+        process_mapping_file(
+            cache,
+            mapping,
+            dep,
+            lockfile,
+            &mut visited,
+            &mut found_proto_deps,
+        )?;
+        inner_loop(cache, dep, lockfile, &mut visited, &mut found_proto_deps)?;
     }
 
     // Select proto files for the transitive dependencies of this dependency
@@ -408,19 +400,17 @@ fn zoom_out_content_root(
         let dep_dir = cache
             .create_worktree(&dep.coordinate, &dep.commit_hash, &dep.name)
             .map_err(ProtoError::Cache)?;
-        for dir in dep_dir.read_dir()? {
-            let proto_files = find_proto_files(&dir?.path())?;
-            if let Some(path) = proto_files
-                .into_iter()
-                .find(|p| p.ends_with(proto_file_source))
-            {
-                trace!(
-                    "[Zoom out] Found path root {} for {}.",
-                    path.to_string_lossy(),
-                    proto_file_source.to_string_lossy()
-                );
-                proto_src = path;
-            }
+        let proto_files = find_proto_files(&dep_dir)?;
+        if let Some(path) = proto_files
+            .into_iter()
+            .find(|p| p.ends_with(proto_file_source))
+        {
+            trace!(
+                "[Zoom out] Found path root {} for {}.",
+                path.to_string_lossy(),
+                proto_file_source.to_string_lossy()
+            );
+            proto_src = path;
         }
     }
     Ok(proto_src)


### PR DESCRIPTION
There seems to be now reason why collecting proto files for a directory is done in two phases (first, iterating through the top-level directories, and then listing each directory recursively). We can as well start the recursion from the top-level directory directly.

This is technically a breaking change, as it means top-level proto files will be also included, when they previously were not. I don't think having to-level protos is common though though, and if someone does it I don't think protofetch should be the limiting factor.