### PR TITLE
feat: parallelize resolve / fetch / copy (CX-40150)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -198,12 +198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,20 +217,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -345,7 +325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -380,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -445,12 +425,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -476,7 +450,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -625,7 +599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -726,15 +700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,17 +710,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "mio"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "num-bigint-dig"
@@ -876,19 +830,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,12 +849,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -992,7 +927,6 @@ dependencies = [
  "anyhow",
  "clap",
  "config",
- "dashmap",
  "env_logger",
  "fs4",
  "git2",
@@ -1005,7 +939,6 @@ dependencies = [
  "ssh-key",
  "tempfile",
  "thiserror",
- "tokio",
  "toml",
 ]
 
@@ -1051,15 +984,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1109,14 +1033,8 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -1177,16 +1095,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
 
 [[package]]
 name = "signature"
@@ -1311,7 +1219,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1342,31 +1250,6 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
-]
-
-[[package]]
-name = "tokio"
-version = "1.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
-dependencies = [
- "libc",
- "mio",
- "pin-project-lite",
- "signal-hook-registry",
- "tokio-macros",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1473,27 +1356,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -198,6 +198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +223,20 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -325,8 +345,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -354,7 +380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -377,6 +403,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -407,6 +445,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -432,7 +476,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -581,7 +625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -682,6 +726,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +745,17 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mio"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint-dig"
@@ -812,6 +876,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +908,12 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -909,6 +992,7 @@ dependencies = [
  "anyhow",
  "clap",
  "config",
+ "dashmap",
  "env_logger",
  "fs4",
  "git2",
@@ -919,7 +1003,9 @@ dependencies = [
  "regex-lite",
  "serde",
  "ssh-key",
+ "tempfile",
  "thiserror",
+ "tokio",
  "toml",
 ]
 
@@ -931,6 +1017,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -958,7 +1050,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1008,8 +1109,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sec1"
@@ -1070,6 +1177,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -1185,6 +1302,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1342,31 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1309,12 +1464,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1389,6 +1568,12 @@ checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ vendored-libgit2 = ["git2/vendored-libgit2"]
 
 [dependencies]
 anyhow = "1.0.98"
-clap = { version = "4.5.36", features = ["derive"] }
+clap = { version = "4.5.36", features = ["derive", "env"] }
 config = { version = "0.15.11", default-features = false, features = ["toml"] }
+dashmap = "6.1.0"
 env_logger = { version = "0.11.8", default-features = false, features = ["auto-color"] }
 fs4 = "0.13.1"
 git2 = ">=0.18.0, <0.21.0"
@@ -30,8 +31,10 @@ regex-lite = "0.1.6"
 serde = { version = "1.0.219", features = ["derive"] }
 ssh-key = "0.6.7"
 thiserror = "2.0.12"
+tokio = { version = "1.40", default-features = false, features = ["rt-multi-thread", "sync", "macros", "signal", "time"] }
 toml = { version = "0.8.20", features = ["preserve_order"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 project-root = "0.2.2"
+tempfile = "3.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ vendored-libgit2 = ["git2/vendored-libgit2"]
 anyhow = "1.0.98"
 clap = { version = "4.5.36", features = ["derive", "env"] }
 config = { version = "0.15.11", default-features = false, features = ["toml"] }
-dashmap = "6.1.0"
 env_logger = { version = "0.11.8", default-features = false, features = ["auto-color"] }
 fs4 = "0.13.1"
 git2 = ">=0.18.0, <0.21.0"
@@ -31,7 +30,6 @@ regex-lite = "0.1.6"
 serde = { version = "1.0.219", features = ["derive"] }
 ssh-key = "0.6.7"
 thiserror = "2.0.12"
-tokio = { version = "1.40", default-features = false, features = ["rt-multi-thread", "sync", "macros", "signal", "time"] }
 toml = { version = "0.8.20", features = ["preserve_order"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ vendored-libgit2 = ["git2/vendored-libgit2"]
 
 [dependencies]
 anyhow = "1.0.98"
-clap = { version = "4.5.36", features = ["derive", "env"], optional = true }
+clap = { version = "4.5.36", features = ["derive"], optional = true }
 config = { version = "0.15.11", default-features = false, features = ["toml"] }
 env_logger = { version = "0.11.8", default-features = false, features = [
 	"auto-color",

--- a/src/api/builder.rs
+++ b/src/api/builder.rs
@@ -1,6 +1,8 @@
-use std::{env, error::Error, path::PathBuf};
+use std::{env, error::Error, path::PathBuf, sync::Arc};
 
-use crate::{config::ProtofetchConfig, git::cache::ProtofetchGitCache, Protofetch};
+use crate::{
+    config::ProtofetchConfig, fetch::ParallelConfig, git::cache::ProtofetchGitCache, Protofetch,
+};
 
 #[derive(Default)]
 pub struct ProtofetchBuilder {
@@ -10,6 +12,7 @@ pub struct ProtofetchBuilder {
     lock_file_name: Option<PathBuf>,
     cache_directory_path: Option<PathBuf>,
     output_directory_name: Option<PathBuf>,
+    parallel: ParallelConfig,
 }
 
 impl ProtofetchBuilder {
@@ -52,6 +55,20 @@ impl ProtofetchBuilder {
         self
     }
 
+    /// Maximum number of in-flight network jobs (resolve + fetch). Defaults
+    /// to 16. Setting `0` falls back to 1 (effectively sequential).
+    pub fn jobs(mut self, jobs: usize) -> Self {
+        self.parallel.network_jobs = jobs.max(1);
+        self
+    }
+
+    /// Maximum number of in-flight disk jobs (worktree + copy). Defaults to
+    /// `max(4, num_cpus / 2)`.
+    pub fn copy_jobs(mut self, jobs: usize) -> Self {
+        self.parallel.copy_jobs = jobs.max(1);
+        self
+    }
+
     pub fn try_build(self) -> Result<Protofetch, Box<dyn Error>> {
         let config = ProtofetchConfig::load()?;
 
@@ -61,6 +78,7 @@ impl ProtofetchBuilder {
             lock_file_name,
             output_directory_name,
             cache_directory_path,
+            parallel,
         } = self;
         let root = match root {
             Some(root) => root,
@@ -73,16 +91,15 @@ impl ProtofetchBuilder {
 
         let cache_directory = root.join(cache_directory_path.unwrap_or(config.cache_dir));
 
-        let git_config = git2::Config::open_default()?;
-
-        let cache = ProtofetchGitCache::new(cache_directory, git_config, config.default_protocol)?;
+        let cache = ProtofetchGitCache::new(cache_directory, config.default_protocol)?;
 
         Ok(Protofetch {
-            cache,
+            cache: Arc::new(cache),
             root,
             module_file_name,
             lock_file_name,
             output_directory_name,
+            parallel,
         })
     }
 }

--- a/src/api/builder.rs
+++ b/src/api/builder.rs
@@ -12,7 +12,8 @@ pub struct ProtofetchBuilder {
     lock_file_name: Option<PathBuf>,
     cache_directory_path: Option<PathBuf>,
     output_directory_name: Option<PathBuf>,
-    parallel: ParallelConfig,
+    jobs: Option<usize>,
+    copy_jobs: Option<usize>,
 }
 
 impl ProtofetchBuilder {
@@ -58,14 +59,14 @@ impl ProtofetchBuilder {
     /// Maximum number of in-flight network jobs (resolve + fetch). Defaults
     /// to 16. Setting `0` falls back to 1 (effectively sequential).
     pub fn jobs(mut self, jobs: usize) -> Self {
-        self.parallel.network_jobs = jobs.max(1);
+        self.jobs = Some(jobs.max(1));
         self
     }
 
     /// Maximum number of in-flight disk jobs (worktree + copy). Defaults to
     /// `max(4, num_cpus / 2)`.
     pub fn copy_jobs(mut self, jobs: usize) -> Self {
-        self.parallel.copy_jobs = jobs.max(1);
+        self.copy_jobs = Some(jobs.max(1));
         self
     }
 
@@ -78,7 +79,8 @@ impl ProtofetchBuilder {
             lock_file_name,
             output_directory_name,
             cache_directory_path,
-            parallel,
+            jobs,
+            copy_jobs,
         } = self;
         let root = match root {
             Some(root) => root,
@@ -92,6 +94,21 @@ impl ProtofetchBuilder {
         let cache_directory = root.join(cache_directory_path.unwrap_or(config.cache_dir));
 
         let cache = ProtofetchGitCache::new(cache_directory, config.default_protocol)?;
+
+        // Build the effective ParallelConfig: defaults < config < explicit builder calls.
+        let mut parallel = ParallelConfig::default();
+        if let Some(j) = config.jobs {
+            parallel.network_jobs = j.max(1);
+        }
+        if let Some(j) = config.copy_jobs {
+            parallel.copy_jobs = j.max(1);
+        }
+        if let Some(j) = jobs {
+            parallel.network_jobs = j;
+        }
+        if let Some(j) = copy_jobs {
+            parallel.copy_jobs = j;
+        }
 
         Ok(Protofetch {
             cache: Arc::new(cache),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,10 +1,12 @@
 use std::{
     error::Error,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use crate::{
     cli::command_handlers::{do_clean, do_fetch, do_init, do_lock, do_migrate},
+    fetch::ParallelConfig,
     git::cache::ProtofetchGitCache,
 };
 
@@ -13,11 +15,12 @@ mod builder;
 pub use builder::ProtofetchBuilder;
 
 pub struct Protofetch {
-    cache: ProtofetchGitCache,
+    cache: Arc<ProtofetchGitCache>,
     root: PathBuf,
     module_file_name: PathBuf,
     lock_file_name: PathBuf,
     output_directory_name: Option<PathBuf>,
+    parallel: ParallelConfig,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -44,11 +47,12 @@ impl Protofetch {
     pub fn fetch(&self, lock_mode: LockMode) -> Result<(), Box<dyn Error>> {
         do_fetch(
             lock_mode,
-            &self.cache,
+            self.cache.clone(),
             &self.root,
             &self.module_file_name,
             &self.lock_file_name,
             self.output_directory_name.as_deref(),
+            self.parallel,
         )
     }
 
@@ -56,10 +60,11 @@ impl Protofetch {
     pub fn lock(&self, lock_mode: LockMode) -> Result<(), Box<dyn Error>> {
         do_lock(
             lock_mode,
-            &self.cache,
+            self.cache.clone(),
             &self.root,
             &self.module_file_name,
             &self.lock_file_name,
+            self.parallel,
         )?;
         Ok(())
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -23,6 +23,12 @@ pub struct Protofetch {
     parallel: ParallelConfig,
 }
 
+#[allow(dead_code)]
+fn _assert_protofetch_auto_traits() {
+    fn assert<T: Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe>() {}
+    assert::<Protofetch>();
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum LockMode {
     /// Verify that the lock file is up to date. This mode should be normally used on CI.

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use crate::model::protofetch::{Coordinate, ModuleName, RevisionSpecification};
 
-pub trait RepositoryCache {
+pub trait RepositoryCache: Send + Sync {
     fn fetch(
         &self,
         coordinate: &Coordinate,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,6 +1,6 @@
 mod git;
 
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use crate::model::protofetch::{Coordinate, ModuleName, RevisionSpecification};
 
@@ -18,4 +18,27 @@ pub trait RepositoryCache: Send + Sync {
         commit_hash: &str,
         name: &ModuleName,
     ) -> anyhow::Result<PathBuf>;
+}
+
+impl<T> RepositoryCache for Arc<T>
+where
+    T: RepositoryCache + ?Sized,
+{
+    fn fetch(
+        &self,
+        coordinate: &Coordinate,
+        specification: &RevisionSpecification,
+        commit_hash: &str,
+    ) -> anyhow::Result<()> {
+        T::fetch(self, coordinate, specification, commit_hash)
+    }
+
+    fn create_worktree(
+        &self,
+        coordinate: &Coordinate,
+        commit_hash: &str,
+        name: &ModuleName,
+    ) -> anyhow::Result<PathBuf> {
+        T::create_worktree(self, coordinate, commit_hash, name)
+    }
 }

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -52,7 +52,13 @@ pub fn do_fetch(
         parallel.network_jobs,
     )?;
 
-    proto::copy_proto_files_parallel(cache.clone(), Arc::new(resolved), proto_out, parallel)?;
+    proto::copy_proto_files_parallel(
+        cache.clone(),
+        Arc::new(resolved),
+        proto_out,
+        cache.coord_locks().clone(),
+        parallel,
+    )?;
 
     Ok(())
 }

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -2,18 +2,19 @@ use log::{debug, info};
 
 use crate::{
     api::LockMode,
-    fetch,
+    fetch::{self, ParallelConfig},
     git::cache::ProtofetchGitCache,
     model::{
         protodep::ProtodepDescriptor,
         protofetch::{lock::LockFile, resolved::ResolvedModule, Descriptor, ModuleName},
     },
     proto,
-    resolver::LockFileModuleResolver,
+    resolver::{LockFileModuleResolver, ModuleResolver},
 };
 use std::{
     error::Error,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 const DEFAULT_OUTPUT_DIRECTORY_NAME: &str = "proto_src";
@@ -21,25 +22,52 @@ const DEFAULT_OUTPUT_DIRECTORY_NAME: &str = "proto_src";
 /// Handler to fetch command
 pub fn do_fetch(
     lock_mode: LockMode,
-    cache: &ProtofetchGitCache,
+    cache: Arc<ProtofetchGitCache>,
     root: &Path,
     module_file_name: &Path,
     lock_file_name: &Path,
     output_directory_name: Option<&Path>,
+    parallel: ParallelConfig,
 ) -> Result<(), Box<dyn Error>> {
     let module_descriptor = load_module_descriptor(root, module_file_name)?;
-
-    let resolved = do_lock(lock_mode, cache, root, module_file_name, lock_file_name)?;
-
     let output_directory_name = output_directory_name
-        .or_else(|| module_descriptor.proto_out_dir.as_ref().map(Path::new))
-        .unwrap_or(Path::new(DEFAULT_OUTPUT_DIRECTORY_NAME));
-    fetch::fetch_sources(cache, &resolved.dependencies)?;
+        .map(Path::to_path_buf)
+        .or_else(|| module_descriptor.proto_out_dir.as_ref().map(PathBuf::from))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_OUTPUT_DIRECTORY_NAME));
+    let proto_out = root.join(output_directory_name);
+    let root_buf = root.to_path_buf();
+    let module_file_name_buf = module_file_name.to_path_buf();
+    let lock_file_name_buf = lock_file_name.to_path_buf();
 
-    //Copy proto_out files to actual target
-    proto::copy_proto_files(cache, &resolved, &root.join(output_directory_name))?;
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()?;
 
-    Ok(())
+    runtime.block_on(async move {
+        let resolved = do_lock_async(
+            lock_mode,
+            cache.clone(),
+            &root_buf,
+            &module_file_name_buf,
+            &lock_file_name_buf,
+            parallel,
+        )
+        .await?;
+
+        fetch::fetch_sources_parallel(
+            cache.clone(),
+            resolved.dependencies.clone(),
+            cache.coord_locks().clone(),
+            parallel.network_jobs,
+        )
+        .await?;
+
+        proto::copy_proto_files_parallel(cache.clone(), Arc::new(resolved), proto_out, parallel)
+            .await?;
+
+        Ok::<(), Box<dyn Error>>(())
+    })
 }
 
 /// Handler to lock command
@@ -47,42 +75,112 @@ pub fn do_fetch(
 /// Generates a lock file based on the protofetch.toml
 pub fn do_lock(
     lock_mode: LockMode,
-    cache: &ProtofetchGitCache,
+    cache: Arc<ProtofetchGitCache>,
     root: &Path,
     module_file_name: &Path,
     lock_file_name: &Path,
+    parallel: ParallelConfig,
+) -> Result<ResolvedModule, Box<dyn Error>> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()?;
+    let root = root.to_path_buf();
+    let module_file_name = module_file_name.to_path_buf();
+    let lock_file_name = lock_file_name.to_path_buf();
+    runtime
+        .block_on(async move {
+            do_lock_async(
+                lock_mode,
+                cache,
+                &root,
+                &module_file_name,
+                &lock_file_name,
+                parallel,
+            )
+            .await
+        })
+}
+
+async fn do_lock_async(
+    lock_mode: LockMode,
+    cache: Arc<ProtofetchGitCache>,
+    root: &Path,
+    module_file_name: &Path,
+    lock_file_name: &Path,
+    parallel: ParallelConfig,
 ) -> Result<ResolvedModule, Box<dyn Error>> {
     let module_descriptor = load_module_descriptor(root, module_file_name)?;
-
     let lock_file_path = root.join(lock_file_name);
 
+    let coord_locks = cache.coord_locks().clone();
     let (old_lock, (resolved, lockfile)) = match (lock_mode, lock_file_path.exists()) {
         (LockMode::Locked, false) => return Err("Lock file does not exist".into()),
 
         (LockMode::Locked, true) => {
             let old_lock = LockFile::from_file(&lock_file_path)?;
-            let resolver = LockFileModuleResolver::new(cache, &old_lock, true);
+            let resolver: Arc<dyn ModuleResolver> = Arc::new(LockFileModuleResolver::new(
+                cache.clone(),
+                old_lock.clone(),
+                true,
+            ));
             debug!("Verifying lockfile...");
-            let resolved = fetch::resolve(&module_descriptor, &resolver)?;
+            let resolved = fetch::parallel::parallel_resolve(
+                &module_descriptor,
+                resolver,
+                coord_locks,
+                parallel.network_jobs,
+            )
+            .await?;
             (Some(old_lock), resolved)
         }
 
         (LockMode::Update, false) => {
             debug!("Generating lockfile...");
-            (None, fetch::resolve(&module_descriptor, &cache)?)
+            let resolver: Arc<dyn ModuleResolver> = cache.clone();
+            (
+                None,
+                fetch::parallel::parallel_resolve(
+                    &module_descriptor,
+                    resolver,
+                    coord_locks,
+                    parallel.network_jobs,
+                )
+                .await?,
+            )
         }
 
         (LockMode::Update, true) => {
             let old_lock = LockFile::from_file(&lock_file_path)?;
-            let resolver = LockFileModuleResolver::new(cache, &old_lock, false);
+            let resolver: Arc<dyn ModuleResolver> = Arc::new(LockFileModuleResolver::new(
+                cache.clone(),
+                old_lock.clone(),
+                false,
+            ));
             debug!("Updating lockfile...");
-            let resolved = fetch::resolve(&module_descriptor, &resolver)?;
+            let resolved = fetch::parallel::parallel_resolve(
+                &module_descriptor,
+                resolver,
+                coord_locks,
+                parallel.network_jobs,
+            )
+            .await?;
             (Some(old_lock), resolved)
         }
 
         (LockMode::Recreate, _) => {
             debug!("Generating lockfile...");
-            (None, fetch::resolve(&module_descriptor, &cache)?)
+            let resolver: Arc<dyn ModuleResolver> = cache.clone();
+            (
+                None,
+                fetch::parallel::parallel_resolve(
+                    &module_descriptor,
+                    resolver,
+                    coord_locks,
+                    parallel.network_jobs,
+                )
+                .await?,
+            )
         }
     };
 
@@ -91,7 +189,6 @@ pub fn do_lock(
     if old_lock.is_some_and(|old_lock| old_lock == lockfile) {
         debug!("Lockfile is up to date");
     } else {
-        let lock_file_path = root.join(lock_file_name);
         std::fs::write(&lock_file_path, lockfile.to_string()?)?;
         info!("Wrote lockfile to {}", lock_file_path.display());
     }

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -88,18 +88,17 @@ pub fn do_lock(
     let root = root.to_path_buf();
     let module_file_name = module_file_name.to_path_buf();
     let lock_file_name = lock_file_name.to_path_buf();
-    runtime
-        .block_on(async move {
-            do_lock_async(
-                lock_mode,
-                cache,
-                &root,
-                &module_file_name,
-                &lock_file_name,
-                parallel,
-            )
-            .await
-        })
+    runtime.block_on(async move {
+        do_lock_async(
+            lock_mode,
+            cache,
+            &root,
+            &module_file_name,
+            &lock_file_name,
+            parallel,
+        )
+        .await
+    })
 }
 
 async fn do_lock_async(

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -35,44 +35,30 @@ pub fn do_fetch(
         .or_else(|| module_descriptor.proto_out_dir.as_ref().map(PathBuf::from))
         .unwrap_or_else(|| PathBuf::from(DEFAULT_OUTPUT_DIRECTORY_NAME));
     let proto_out = root.join(output_directory_name);
-    let root_buf = root.to_path_buf();
-    let module_file_name_buf = module_file_name.to_path_buf();
-    let lock_file_name_buf = lock_file_name.to_path_buf();
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(2)
-        .enable_all()
-        .build()?;
+    let resolved = do_lock_inner(
+        lock_mode,
+        cache.clone(),
+        root,
+        module_file_name,
+        lock_file_name,
+        parallel,
+    )?;
 
-    runtime.block_on(async move {
-        let resolved = do_lock_async(
-            lock_mode,
-            cache.clone(),
-            &root_buf,
-            &module_file_name_buf,
-            &lock_file_name_buf,
-            parallel,
-        )
-        .await?;
+    fetch::fetch_sources_parallel(
+        cache.clone(),
+        resolved.dependencies.clone(),
+        cache.coord_locks().clone(),
+        parallel.network_jobs,
+    )?;
 
-        fetch::fetch_sources_parallel(
-            cache.clone(),
-            resolved.dependencies.clone(),
-            cache.coord_locks().clone(),
-            parallel.network_jobs,
-        )
-        .await?;
+    proto::copy_proto_files_parallel(cache.clone(), Arc::new(resolved), proto_out, parallel)?;
 
-        proto::copy_proto_files_parallel(cache.clone(), Arc::new(resolved), proto_out, parallel)
-            .await?;
-
-        Ok::<(), Box<dyn Error>>(())
-    })
+    Ok(())
 }
 
-/// Handler to lock command
-/// Loads dependency descriptor from protofetch toml or protodep toml
-/// Generates a lock file based on the protofetch.toml
+/// Handler to lock command. Loads dependency descriptor from protofetch toml
+/// or protodep toml. Generates a lock file based on the protofetch.toml.
 pub fn do_lock(
     lock_mode: LockMode,
     cache: Arc<ProtofetchGitCache>,
@@ -81,27 +67,17 @@ pub fn do_lock(
     lock_file_name: &Path,
     parallel: ParallelConfig,
 ) -> Result<ResolvedModule, Box<dyn Error>> {
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(2)
-        .enable_all()
-        .build()?;
-    let root = root.to_path_buf();
-    let module_file_name = module_file_name.to_path_buf();
-    let lock_file_name = lock_file_name.to_path_buf();
-    runtime.block_on(async move {
-        do_lock_async(
-            lock_mode,
-            cache,
-            &root,
-            &module_file_name,
-            &lock_file_name,
-            parallel,
-        )
-        .await
-    })
+    do_lock_inner(
+        lock_mode,
+        cache,
+        root,
+        module_file_name,
+        lock_file_name,
+        parallel,
+    )
 }
 
-async fn do_lock_async(
+fn do_lock_inner(
     lock_mode: LockMode,
     cache: Arc<ProtofetchGitCache>,
     root: &Path,
@@ -129,8 +105,7 @@ async fn do_lock_async(
                 resolver,
                 coord_locks,
                 parallel.network_jobs,
-            )
-            .await?;
+            )?;
             (Some(old_lock), resolved)
         }
 
@@ -144,8 +119,7 @@ async fn do_lock_async(
                     resolver,
                     coord_locks,
                     parallel.network_jobs,
-                )
-                .await?,
+                )?,
             )
         }
 
@@ -162,8 +136,7 @@ async fn do_lock_async(
                 resolver,
                 coord_locks,
                 parallel.network_jobs,
-            )
-            .await?;
+            )?;
             (Some(old_lock), resolved)
         }
 
@@ -177,8 +150,7 @@ async fn do_lock_async(
                     resolver,
                     coord_locks,
                     parallel.network_jobs,
-                )
-                .await?,
+                )?,
             )
         }
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ use crate::model::protofetch::Protocol;
 pub struct ProtofetchConfig {
     pub cache_dir: PathBuf,
     pub default_protocol: Protocol,
+    pub jobs: Option<usize>,
+    pub copy_jobs: Option<usize>,
 }
 
 impl ProtofetchConfig {
@@ -24,6 +26,8 @@ impl ProtofetchConfig {
                 None => default_cache_dir()?,
             },
             default_protocol: raw_config.git.protocol.unwrap_or(Protocol::Ssh),
+            jobs: raw_config.jobs,
+            copy_jobs: raw_config.copy_jobs,
         };
         trace!("Loaded configuration: {:?}", config);
 
@@ -37,6 +41,10 @@ struct RawConfig {
     cache: CacheConfig,
     #[serde(default)]
     git: GitConfig,
+    #[serde(default)]
+    jobs: Option<usize>,
+    #[serde(default)]
+    copy_jobs: Option<usize>,
 }
 
 #[derive(Default, Debug, Deserialize, PartialEq, Eq)]
@@ -70,10 +78,20 @@ impl RawConfig {
             ));
         }
 
+        // First pass: nested keys via `_` separator (maps PROTOFETCH_CACHE_DIR
+        // → cache.dir, PROTOFETCH_GIT_PROTOCOL → git.protocol, etc.).
+        // Second pass: flat keys with no separator (maps PROTOFETCH_JOBS →
+        // jobs, PROTOFETCH_COPY_JOBS → copy_jobs).  Sources added later win,
+        // so the flat-key pass takes precedence for the top-level fields.
         builder
             .add_source(
                 Environment::with_prefix("PROTOFETCH")
                     .separator("_")
+                    .source(env_override.clone()),
+            )
+            .add_source(
+                Environment::with_prefix("PROTOFETCH")
+                    .prefix_separator("_")
                     .source(env_override),
             )
             .build()?
@@ -128,7 +146,9 @@ mod tests {
             config,
             RawConfig {
                 cache: CacheConfig { dir: None },
-                git: GitConfig { protocol: None }
+                git: GitConfig { protocol: None },
+                jobs: None,
+                copy_jobs: None,
             }
         )
     }
@@ -148,9 +168,22 @@ mod tests {
                 },
                 git: GitConfig {
                     protocol: Some(Protocol::Ssh)
-                }
+                },
+                jobs: None,
+                copy_jobs: None,
             }
         )
+    }
+
+    #[test]
+    fn load_environment_parallelism() {
+        let env = HashMap::from([
+            ("PROTOFETCH_JOBS".to_owned(), "16".to_owned()),
+            ("PROTOFETCH_COPY_JOBS".to_owned(), "4".to_owned()),
+        ]);
+        let config = RawConfig::load(None, Some(Default::default()), Some(env)).unwrap();
+        assert_eq!(config.jobs, Some(16));
+        assert_eq!(config.copy_jobs, Some(4));
     }
 
     #[test]
@@ -176,7 +209,9 @@ mod tests {
                 },
                 git: GitConfig {
                     protocol: Some(Protocol::Ssh)
-                }
+                },
+                jobs: None,
+                copy_jobs: None,
             }
         )
     }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -1,14 +1,13 @@
 pub mod parallel;
 
-use std::{str::Utf8Error, sync::Arc};
+use std::{str::Utf8Error, sync::Arc, thread};
 
 use crate::{
     cache::RepositoryCache, git::coord_locks::CoordinateLocks,
-    model::protofetch::resolved::ResolvedDependency,
+    model::protofetch::resolved::ResolvedDependency, sync::Semaphore,
 };
 use log::info;
 use thiserror::Error;
-use tokio::{sync::Semaphore, task::JoinSet};
 
 pub use parallel::ParallelConfig;
 
@@ -141,10 +140,10 @@ pub fn resolve(
     Ok((resolved, lockfile))
 }
 
-/// Fans dependencies out across the
-/// blocking pool, gated by `network_jobs` and serialized per-coordinate so two
-/// fetches into the same on-disk bare repo don't race.
-pub async fn fetch_sources_parallel<C>(
+/// Fans dependencies out across `network_jobs` worker threads, gated by
+/// the network semaphore and serialized per-coordinate so two fetches into
+/// the same on-disk bare repo don't race.
+pub fn fetch_sources_parallel<C>(
     cache: Arc<C>,
     dependencies: Vec<ResolvedDependency>,
     coord_locks: CoordinateLocks,
@@ -154,35 +153,32 @@ where
     C: RepositoryCache + 'static,
 {
     info!("Fetching dependencies source files...");
-    let net_sem = Arc::new(Semaphore::new(network_jobs.max(1)));
-    let mut set = JoinSet::new();
+    let net_sem = Semaphore::new(network_jobs.max(1));
 
-    for dependency in dependencies {
-        let permit = net_sem
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("semaphore closed");
-        let cache = cache.clone();
-        let coord_lock = coord_locks.lock_for(&dependency.coordinate);
-        set.spawn_blocking(move || {
-            let _permit = permit;
-            let _g = coord_lock.lock().expect("coord lock poisoned");
-            cache
-                .fetch(
-                    &dependency.coordinate,
-                    &dependency.specification,
-                    &dependency.commit_hash,
-                )
-                .map_err(FetchError::Cache)
-        });
-    }
-
-    while let Some(joined) = set.join_next().await {
-        let outcome = joined.map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))?;
-        outcome?;
-    }
-    Ok(())
+    thread::scope(|s| -> Result<(), FetchError> {
+        let mut handles = Vec::with_capacity(dependencies.len());
+        for dependency in dependencies {
+            let cache = cache.clone();
+            let coord_lock = coord_locks.lock_for(&dependency.coordinate);
+            let net_sem = &net_sem;
+            handles.push(s.spawn(move || {
+                let _permit = net_sem.acquire();
+                let _g = coord_lock.lock().expect("coord lock poisoned");
+                cache
+                    .fetch(
+                        &dependency.coordinate,
+                        &dependency.specification,
+                        &dependency.commit_hash,
+                    )
+                    .map_err(FetchError::Cache)
+            }));
+        }
+        for h in handles {
+            h.join()
+                .map_err(|_| FetchError::Resolver(anyhow::anyhow!("worker thread panicked")))??;
+        }
+        Ok(())
+    })
 }
 
 #[cfg(test)]

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -3,8 +3,7 @@ pub mod parallel;
 use std::{str::Utf8Error, sync::Arc};
 
 use crate::{
-    cache::RepositoryCache,
-    git::coord_locks::CoordinateLocks,
+    cache::RepositoryCache, git::coord_locks::CoordinateLocks,
     model::protofetch::resolved::ResolvedDependency,
 };
 use log::info;
@@ -13,8 +12,6 @@ use tokio::{sync::Semaphore, task::JoinSet};
 
 pub use parallel::ParallelConfig;
 
-#[cfg(test)]
-use std::collections::BTreeMap;
 #[cfg(test)]
 use crate::{
     model::protofetch::{
@@ -26,6 +23,8 @@ use crate::{
 };
 #[cfg(test)]
 use log::error;
+#[cfg(test)]
+use std::collections::BTreeMap;
 
 #[derive(Error, Debug)]
 pub enum FetchError {

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -1,16 +1,31 @@
-use std::{collections::BTreeMap, str::Utf8Error};
+pub mod parallel;
+
+use std::{str::Utf8Error, sync::Arc};
 
 use crate::{
     cache::RepositoryCache,
+    git::coord_locks::CoordinateLocks,
+    model::protofetch::resolved::ResolvedDependency,
+};
+use log::info;
+use thiserror::Error;
+use tokio::{sync::Semaphore, task::JoinSet};
+
+pub use parallel::ParallelConfig;
+
+#[cfg(test)]
+use std::collections::BTreeMap;
+#[cfg(test)]
+use crate::{
     model::protofetch::{
         lock::{LockFile, LockedCoordinate, LockedDependency},
-        resolved::{ResolvedDependency, ResolvedModule},
+        resolved::ResolvedModule,
         Dependency, Descriptor, ModuleName,
     },
     resolver::{CommitAndDescriptor, ModuleResolver},
 };
-use log::{error, info};
-use thiserror::Error;
+#[cfg(test)]
+use log::error;
 
 #[derive(Error, Debug)]
 pub enum FetchError {
@@ -30,6 +45,8 @@ pub enum FetchError {
     Resolver(anyhow::Error),
 }
 
+/// Sequential resolver kept for unit-test parity with the parallel implementation.
+#[cfg(test)]
 pub fn resolve(
     descriptor: &Descriptor,
     resolver: &impl ModuleResolver,
@@ -125,21 +142,47 @@ pub fn resolve(
     Ok((resolved, lockfile))
 }
 
-pub fn fetch_sources(
-    cache: &impl RepositoryCache,
-    dependencies: &[ResolvedDependency],
-) -> Result<(), FetchError> {
+/// Fans dependencies out across the
+/// blocking pool, gated by `network_jobs` and serialized per-coordinate so two
+/// fetches into the same on-disk bare repo don't race.
+pub async fn fetch_sources_parallel<C>(
+    cache: Arc<C>,
+    dependencies: Vec<ResolvedDependency>,
+    coord_locks: CoordinateLocks,
+    network_jobs: usize,
+) -> Result<(), FetchError>
+where
+    C: RepositoryCache + 'static,
+{
     info!("Fetching dependencies source files...");
+    let net_sem = Arc::new(Semaphore::new(network_jobs.max(1)));
+    let mut set = JoinSet::new();
+
     for dependency in dependencies {
-        cache
-            .fetch(
-                &dependency.coordinate,
-                &dependency.specification,
-                &dependency.commit_hash,
-            )
-            .map_err(FetchError::Cache)?;
+        let permit = net_sem
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("semaphore closed");
+        let cache = cache.clone();
+        let coord_lock = coord_locks.lock_for(&dependency.coordinate);
+        set.spawn_blocking(move || {
+            let _permit = permit;
+            let _g = coord_lock.lock().expect("coord lock poisoned");
+            cache
+                .fetch(
+                    &dependency.coordinate,
+                    &dependency.specification,
+                    &dependency.commit_hash,
+                )
+                .map_err(FetchError::Cache)
+        });
     }
 
+    while let Some(joined) = set.join_next().await {
+        let outcome = joined.map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))?;
+        outcome?;
+    }
     Ok(())
 }
 

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -174,8 +174,12 @@ where
             }));
         }
         for h in handles {
-            h.join()
-                .map_err(|_| FetchError::Resolver(anyhow::anyhow!("worker thread panicked")))??;
+            h.join().map_err(|payload| {
+                FetchError::Resolver(anyhow::anyhow!(
+                    "worker thread panicked: {}",
+                    crate::sync::panic_payload_to_string(payload)
+                ))
+            })??;
         }
         Ok(())
     })

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -1,6 +1,6 @@
 pub mod parallel;
 
-use std::{str::Utf8Error, sync::Arc, thread};
+use std::{str::Utf8Error, thread};
 
 use crate::{
     cache::RepositoryCache, git::coord_locks::CoordinateLocks,
@@ -10,20 +10,6 @@ use log::info;
 use thiserror::Error;
 
 pub use parallel::ParallelConfig;
-
-#[cfg(test)]
-use crate::{
-    model::protofetch::{
-        lock::{LockFile, LockedCoordinate, LockedDependency},
-        resolved::ResolvedModule,
-        Dependency, Descriptor, ModuleName,
-    },
-    resolver::{CommitAndDescriptor, ModuleResolver},
-};
-#[cfg(test)]
-use log::error;
-#[cfg(test)]
-use std::collections::BTreeMap;
 
 #[derive(Error, Debug)]
 pub enum FetchError {
@@ -43,114 +29,17 @@ pub enum FetchError {
     Resolver(anyhow::Error),
 }
 
-/// Sequential resolver kept for unit-test parity with the parallel implementation.
-#[cfg(test)]
-pub fn resolve(
-    descriptor: &Descriptor,
-    resolver: &impl ModuleResolver,
-) -> Result<(ResolvedModule, LockFile), FetchError> {
-    fn go(
-        resolver: &impl ModuleResolver,
-        results: &mut BTreeMap<ModuleName, (LockedDependency, ResolvedDependency)>,
-        dependencies: &[Dependency],
-    ) -> Result<(), FetchError> {
-        let mut children = Vec::new();
-        for dependency in dependencies {
-            let locked_coordinate = LockedCoordinate::from(&dependency.coordinate);
-            match results.get(&dependency.name) {
-                None => {
-                    log::info!("Resolving {}", dependency.coordinate);
-                    let CommitAndDescriptor {
-                        commit_hash,
-                        mut descriptor,
-                    } = resolver
-                        .resolve(
-                            &dependency.coordinate,
-                            &dependency.specification,
-                            None,
-                            &dependency.name,
-                        )
-                        .map_err(FetchError::Resolver)?;
-
-                    let locked = LockedDependency {
-                        name: dependency.name.clone(),
-                        commit_hash: commit_hash.clone(),
-                        coordinate: locked_coordinate,
-                        specification: dependency.specification.clone(),
-                    };
-
-                    let resolved = ResolvedDependency {
-                        name: dependency.name.clone(),
-                        commit_hash,
-                        coordinate: dependency.coordinate.clone(),
-                        specification: dependency.specification.clone(),
-                        rules: dependency.rules.clone(),
-                        dependencies: descriptor
-                            .dependencies
-                            .iter()
-                            .map(|d| d.name.clone())
-                            .collect(),
-                    };
-
-                    results.insert(dependency.name.clone(), (locked, resolved));
-                    children.append(&mut descriptor.dependencies);
-                }
-                Some((already_locked, _)) => {
-                    if already_locked.coordinate != locked_coordinate {
-                        log::warn!(
-                            "discarded {} in favor of {} for {}",
-                            dependency.coordinate,
-                            already_locked.coordinate,
-                            &dependency.name
-                        );
-                    } else if already_locked.specification != dependency.specification {
-                        log::warn!(
-                            "discarded {} in favor of {} for {}",
-                            dependency.specification,
-                            already_locked.specification,
-                            &dependency.name
-                        );
-                    }
-                }
-            }
-        }
-
-        if !children.is_empty() {
-            go(resolver, results, &children)?;
-        }
-
-        Ok(())
-    }
-
-    let mut results = BTreeMap::new();
-
-    go(resolver, &mut results, &descriptor.dependencies)?;
-
-    let (locked, resolved) = results.into_values().unzip();
-
-    let resolved = ResolvedModule {
-        module_name: descriptor.name.clone(),
-        dependencies: resolved,
-    };
-
-    let lockfile = LockFile {
-        dependencies: locked,
-    };
-
-    Ok((resolved, lockfile))
-}
-
 /// Fans dependencies out across `network_jobs` worker threads, gated by
 /// the network semaphore and serialized per-coordinate so two fetches into
 /// the same on-disk bare repo don't race.
 pub fn fetch_sources_parallel<C>(
-    cache: Arc<C>,
+    cache: C,
     dependencies: Vec<ResolvedDependency>,
     coord_locks: CoordinateLocks,
     network_jobs: usize,
 ) -> Result<(), FetchError>
 where
-    C: RepositoryCache + 'static,
+    C: RepositoryCache + Clone + 'static,
 {
     info!("Fetching dependencies source files...");
     let net_sem = Semaphore::new(network_jobs.max(1));
@@ -174,29 +63,129 @@ where
             }));
         }
         for h in handles {
-            h.join().map_err(|payload| {
-                FetchError::Resolver(anyhow::anyhow!(
-                    "worker thread panicked: {}",
-                    crate::sync::panic_payload_to_string(payload)
-                ))
-            })??;
+            match h.join() {
+                Ok(result) => result?,
+                Err(payload) => std::panic::resume_unwind(payload),
+            }
         }
         Ok(())
     })
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
+    use std::collections::BTreeMap;
+
     use anyhow::anyhow;
 
     use crate::{
-        model::protofetch::{Coordinate, Revision, RevisionSpecification, Rules},
-        resolver::CommitAndDescriptor,
+        model::protofetch::{
+            lock::{LockFile, LockedCoordinate, LockedDependency},
+            resolved::ResolvedModule,
+            Coordinate, Dependency, Descriptor, ModuleName, Revision, RevisionSpecification, Rules,
+        },
+        resolver::{CommitAndDescriptor, ModuleResolver},
     };
 
     use super::*;
 
     use pretty_assertions::assert_eq;
+
+    /// Sequential resolver kept for unit-test parity with the parallel implementation.
+    pub(crate) fn resolve(
+        descriptor: &Descriptor,
+        resolver: &impl ModuleResolver,
+    ) -> Result<(ResolvedModule, LockFile), FetchError> {
+        fn go(
+            resolver: &impl ModuleResolver,
+            results: &mut BTreeMap<ModuleName, (LockedDependency, ResolvedDependency)>,
+            dependencies: &[Dependency],
+        ) -> Result<(), FetchError> {
+            let mut children = Vec::new();
+            for dependency in dependencies {
+                let locked_coordinate = LockedCoordinate::from(&dependency.coordinate);
+                match results.get(&dependency.name) {
+                    None => {
+                        log::info!("Resolving {}", dependency.coordinate);
+                        let CommitAndDescriptor {
+                            commit_hash,
+                            mut descriptor,
+                        } = resolver
+                            .resolve(
+                                &dependency.coordinate,
+                                &dependency.specification,
+                                None,
+                                &dependency.name,
+                            )
+                            .map_err(FetchError::Resolver)?;
+
+                        let locked = LockedDependency {
+                            name: dependency.name.clone(),
+                            commit_hash: commit_hash.clone(),
+                            coordinate: locked_coordinate,
+                            specification: dependency.specification.clone(),
+                        };
+
+                        let resolved = ResolvedDependency {
+                            name: dependency.name.clone(),
+                            commit_hash,
+                            coordinate: dependency.coordinate.clone(),
+                            specification: dependency.specification.clone(),
+                            rules: dependency.rules.clone(),
+                            dependencies: descriptor
+                                .dependencies
+                                .iter()
+                                .map(|d| d.name.clone())
+                                .collect(),
+                        };
+
+                        results.insert(dependency.name.clone(), (locked, resolved));
+                        children.append(&mut descriptor.dependencies);
+                    }
+                    Some((already_locked, _)) => {
+                        if already_locked.coordinate != locked_coordinate {
+                            log::warn!(
+                                "discarded {} in favor of {} for {}",
+                                dependency.coordinate,
+                                already_locked.coordinate,
+                                &dependency.name
+                            );
+                        } else if already_locked.specification != dependency.specification {
+                            log::warn!(
+                                "discarded {} in favor of {} for {}",
+                                dependency.specification,
+                                already_locked.specification,
+                                &dependency.name
+                            );
+                        }
+                    }
+                }
+            }
+
+            if !children.is_empty() {
+                go(resolver, results, &children)?;
+            }
+
+            Ok(())
+        }
+
+        let mut results = BTreeMap::new();
+
+        go(resolver, &mut results, &descriptor.dependencies)?;
+
+        let (locked, resolved) = results.into_values().unzip();
+
+        let resolved = ResolvedModule {
+            module_name: descriptor.name.clone(),
+            dependencies: resolved,
+        };
+
+        let lockfile = LockFile {
+            dependencies: locked,
+        };
+
+        Ok((resolved, lockfile))
+    }
 
     #[derive(Default)]
     struct FakeModuleResolver {

--- a/src/fetch/parallel.rs
+++ b/src/fetch/parallel.rs
@@ -38,10 +38,13 @@ impl Default for ParallelConfig {
     }
 }
 
-/// Run dependency resolution in parallel, fanning out across the blocking
-/// pool. Behavior matches the sequential resolver in [`crate::fetch::resolve`]:
-/// the same `ModuleName` resolved twice keeps the first occurrence and a
-/// warning is logged for any conflicting coordinate or revision specification.
+/// Run dependency resolution in parallel, level-by-level BFS over the
+/// dep graph. Within one level, sibling deps are resolved concurrently;
+/// between levels we wait for all in-flight tasks before scheduling the
+/// next level so the per-name dedup is deterministic and matches the
+/// sequential resolver's "first wins + warn" semantics: at each level
+/// deps are considered in declaration order (parent's order, then each
+/// parent's children in declaration order).
 ///
 /// `network_jobs` caps the number of concurrent resolver invocations.
 /// `coord_locks` serializes calls hitting the same on-disk bare repo.
@@ -55,114 +58,117 @@ where
     R: ModuleResolver + ?Sized + 'static,
 {
     let net_sem = Arc::new(Semaphore::new(network_jobs.max(1)));
-    let mut set = JoinSet::new();
 
     // Per-name dedup: tracks the (coord, spec) we first saw for a name so we
     // can match the sequential implementation's "first wins + warn" semantics.
     let mut seen: HashMap<ModuleName, (LockedCoordinate, RevisionSpecification)> = HashMap::new();
     let mut results: BTreeMap<ModuleName, (LockedDependency, ResolvedDependency)> = BTreeMap::new();
 
-    let mut to_schedule: Vec<Dependency> = descriptor.dependencies.clone();
-    let consider_dependency =
-        |dep: Dependency,
-         seen: &mut HashMap<ModuleName, (LockedCoordinate, RevisionSpecification)>|
-         -> Option<Dependency> {
-            let locked_coord = LockedCoordinate::from(&dep.coordinate);
-            match seen.get(&dep.name) {
-                None => {
-                    seen.insert(dep.name.clone(), (locked_coord, dep.specification.clone()));
-                    Some(dep)
-                }
-                Some((existing_coord, existing_spec)) => {
-                    if existing_coord != &locked_coord {
-                        warn!(
-                            "discarded {} in favor of {} for {}",
-                            dep.coordinate, existing_coord, &dep.name
-                        );
-                    } else if existing_spec != &dep.specification {
-                        warn!(
-                            "discarded {} in favor of {} for {}",
-                            dep.specification, existing_spec, &dep.name
-                        );
-                    }
-                    None
-                }
-            }
-        };
-
-    fn spawn_resolve<R>(
-        set: &mut JoinSet<Result<(Dependency, CommitAndDescriptor), FetchError>>,
-        net_sem: &Arc<Semaphore>,
-        coord_locks: &CoordinateLocks,
-        resolver: &Arc<R>,
+    fn consider_dependency(
         dep: Dependency,
-    ) where
-        R: ModuleResolver + ?Sized + 'static,
-    {
-        let net_sem = net_sem.clone();
-        let coord_lock = coord_locks.lock_for(&dep.coordinate);
-        let resolver = resolver.clone();
-        set.spawn(async move {
-            let permit = net_sem
-                .acquire_owned()
-                .await
-                .expect("network semaphore closed");
-            let dep_for_blocking = dep.clone();
-            let result = tokio::task::spawn_blocking(move || {
-                let _permit = permit;
-                let _g = coord_lock.lock().expect("coord lock poisoned");
-                info!("Resolving {}", dep_for_blocking.coordinate);
-                resolver.resolve(
-                    &dep_for_blocking.coordinate,
-                    &dep_for_blocking.specification,
-                    None,
-                    &dep_for_blocking.name,
-                )
-            })
-            .await
-            .map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))?
-            .map_err(FetchError::Resolver)?;
-            Ok((dep, result))
-        });
-    }
-
-    for dep in to_schedule.drain(..) {
-        if let Some(dep) = consider_dependency(dep, &mut seen) {
-            spawn_resolve(&mut set, &net_sem, &coord_locks, &resolver, dep);
+        seen: &mut HashMap<ModuleName, (LockedCoordinate, RevisionSpecification)>,
+    ) -> Option<Dependency> {
+        let locked_coord = LockedCoordinate::from(&dep.coordinate);
+        match seen.get(&dep.name) {
+            None => {
+                seen.insert(dep.name.clone(), (locked_coord, dep.specification.clone()));
+                Some(dep)
+            }
+            Some((existing_coord, existing_spec)) => {
+                if existing_coord != &locked_coord {
+                    warn!(
+                        "discarded {} in favor of {} for {}",
+                        dep.coordinate, existing_coord, &dep.name
+                    );
+                } else if existing_spec != &dep.specification {
+                    warn!(
+                        "discarded {} in favor of {} for {}",
+                        dep.specification, existing_spec, &dep.name
+                    );
+                }
+                None
+            }
         }
     }
 
-    while let Some(joined) = set.join_next().await {
-        let (dep, cd) = joined.map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))??;
-        let CommitAndDescriptor {
-            commit_hash,
-            descriptor: dep_descriptor,
-        } = cd;
+    let mut level: Vec<Dependency> = descriptor.dependencies.clone();
 
-        let locked = LockedDependency {
-            name: dep.name.clone(),
-            commit_hash: commit_hash.clone(),
-            coordinate: LockedCoordinate::from(&dep.coordinate),
-            specification: dep.specification.clone(),
-        };
-        let resolved = ResolvedDependency {
-            name: dep.name.clone(),
-            commit_hash,
-            coordinate: dep.coordinate.clone(),
-            specification: dep.specification.clone(),
-            rules: dep.rules.clone(),
-            dependencies: dep_descriptor
-                .dependencies
-                .iter()
-                .map(|d| d.name.clone())
-                .collect(),
-        };
-        results.insert(dep.name.clone(), (locked, resolved));
-
-        for child in dep_descriptor.dependencies {
-            if let Some(child) = consider_dependency(child, &mut seen) {
-                spawn_resolve(&mut set, &net_sem, &coord_locks, &resolver, child);
+    while !level.is_empty() {
+        // Dedup the upcoming level in declaration order before scheduling so
+        // the lockfile output is deterministic regardless of completion order.
+        let mut to_schedule: Vec<(usize, Dependency)> = Vec::new();
+        for dep in level.drain(..) {
+            if let Some(dep) = consider_dependency(dep, &mut seen) {
+                to_schedule.push((to_schedule.len(), dep));
             }
+        }
+
+        let mut set: JoinSet<Result<(usize, Dependency, CommitAndDescriptor), FetchError>> =
+            JoinSet::new();
+        for (idx, dep) in to_schedule {
+            let net_sem = net_sem.clone();
+            let coord_lock = coord_locks.lock_for(&dep.coordinate);
+            let resolver = resolver.clone();
+            set.spawn(async move {
+                let permit = net_sem
+                    .acquire_owned()
+                    .await
+                    .expect("network semaphore closed");
+                let dep_for_blocking = dep.clone();
+                let result = tokio::task::spawn_blocking(move || {
+                    let _permit = permit;
+                    let _g = coord_lock.lock().expect("coord lock poisoned");
+                    info!("Resolving {}", dep_for_blocking.coordinate);
+                    resolver.resolve(
+                        &dep_for_blocking.coordinate,
+                        &dep_for_blocking.specification,
+                        None,
+                        &dep_for_blocking.name,
+                    )
+                })
+                .await
+                .map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))?
+                .map_err(FetchError::Resolver)?;
+                Ok((idx, dep, result))
+            });
+        }
+
+        // Collect results, then sort by schedule index so the next level's
+        // children appear in declaration order (parent1's children first,
+        // parent2's next, etc.).
+        let mut completed: Vec<(usize, Dependency, CommitAndDescriptor)> = Vec::new();
+        while let Some(joined) = set.join_next().await {
+            completed.push(joined.map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))??);
+        }
+        completed.sort_by_key(|(i, _, _)| *i);
+
+        for (_, dep, cd) in completed {
+            let CommitAndDescriptor {
+                commit_hash,
+                descriptor: dep_descriptor,
+            } = cd;
+
+            let locked = LockedDependency {
+                name: dep.name.clone(),
+                commit_hash: commit_hash.clone(),
+                coordinate: LockedCoordinate::from(&dep.coordinate),
+                specification: dep.specification.clone(),
+            };
+            let resolved = ResolvedDependency {
+                name: dep.name.clone(),
+                commit_hash,
+                coordinate: dep.coordinate.clone(),
+                specification: dep.specification.clone(),
+                rules: dep.rules.clone(),
+                dependencies: dep_descriptor
+                    .dependencies
+                    .iter()
+                    .map(|d| d.name.clone())
+                    .collect(),
+            };
+            results.insert(dep.name.clone(), (locked, resolved));
+
+            level.extend(dep_descriptor.dependencies);
         }
     }
 
@@ -336,6 +342,55 @@ mod tests {
 
         assert!(parallel.dependencies.contains(&locked("bar", "1.0.0", "c3")));
         assert!(parallel.dependencies.contains(&locked("foo", "1.0.0", "c1")));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn transitive_conflicts_dedupe_in_declaration_order() {
+        // Regression test: two parents at level 0 each pull a child named
+        // "shared" but at different coords. Whichever parent appears first in
+        // the descriptor must win, regardless of which task completes first.
+        // (Without level-by-level scheduling, the late-completer's child
+        // could register first in `seen`, producing a non-deterministic
+        // lockfile and breaking `--locked` mode against transitive deps.)
+        let entries = [
+            (
+                "fast_parent",
+                "1.0.0",
+                "p_fast",
+                vec![dep("shared", "from_fast")],
+            ),
+            (
+                "slow_parent",
+                "1.0.0",
+                "p_slow",
+                vec![dep("shared", "from_slow")],
+            ),
+            ("shared", "from_fast", "h_fast", Vec::new()),
+            ("shared", "from_slow", "h_slow", Vec::new()),
+        ];
+        let descriptor = Descriptor {
+            name: ModuleName::from("root"),
+            description: None,
+            proto_out_dir: None,
+            // slow_parent declared FIRST — its transitive child must win.
+            dependencies: vec![dep("slow_parent", "1.0.0"), dep("fast_parent", "1.0.0")],
+        };
+
+        // Run many times; deterministic dedup must always pick slow_parent's
+        // child even though scheduling order can flap under load.
+        for _ in 0..30 {
+            let resolver = Arc::new(build_resolver_with(&entries));
+            let (_, lf) =
+                parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
+                    .await
+                    .unwrap();
+            let shared = lf
+                .dependencies
+                .iter()
+                .find(|d| d.name == ModuleName::from("shared"))
+                .expect("shared in lockfile");
+            assert_eq!(shared.commit_hash, "h_slow");
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/src/fetch/parallel.rs
+++ b/src/fetch/parallel.rs
@@ -267,8 +267,10 @@ mod tests {
     }
 
     fn build_resolver_with(deps: &[(&str, &str, &str, Vec<Dependency>)]) -> FakeResolver {
-        let mut entries: BTreeMap<Coordinate, BTreeMap<RevisionSpecification, CommitAndDescriptor>> =
-            BTreeMap::new();
+        let mut entries: BTreeMap<
+            Coordinate,
+            BTreeMap<RevisionSpecification, CommitAndDescriptor>,
+        > = BTreeMap::new();
         for (name, rev, hash, child_deps) in deps {
             entries.entry(coord(name)).or_default().insert(
                 RevisionSpecification {
@@ -310,15 +312,18 @@ mod tests {
         let (_, sequential) = resolve(&descriptor, &resolver).unwrap();
 
         let resolver = Arc::new(build_resolver_with(&entries));
-        let (_, parallel) =
-            parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
-                .await
-                .unwrap();
+        let (_, parallel) = parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
+            .await
+            .unwrap();
 
         assert_eq!(parallel, sequential);
         assert_eq!(parallel.dependencies.len(), 2);
-        assert!(parallel.dependencies.contains(&locked("bar", "2.0.0", "c2")));
-        assert!(parallel.dependencies.contains(&locked("foo", "1.0.0", "c1")));
+        assert!(parallel
+            .dependencies
+            .contains(&locked("bar", "2.0.0", "c2")));
+        assert!(parallel
+            .dependencies
+            .contains(&locked("foo", "1.0.0", "c1")));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -335,13 +340,16 @@ mod tests {
             dependencies: vec![dep("foo", "1.0.0"), dep("bar", "1.0.0")],
         };
         let resolver = Arc::new(build_resolver_with(&entries));
-        let (_, parallel) =
-            parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
-                .await
-                .unwrap();
+        let (_, parallel) = parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
+            .await
+            .unwrap();
 
-        assert!(parallel.dependencies.contains(&locked("bar", "1.0.0", "c3")));
-        assert!(parallel.dependencies.contains(&locked("foo", "1.0.0", "c1")));
+        assert!(parallel
+            .dependencies
+            .contains(&locked("bar", "1.0.0", "c3")));
+        assert!(parallel
+            .dependencies
+            .contains(&locked("foo", "1.0.0", "c1")));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -380,10 +388,9 @@ mod tests {
         // child even though scheduling order can flap under load.
         for _ in 0..30 {
             let resolver = Arc::new(build_resolver_with(&entries));
-            let (_, lf) =
-                parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
-                    .await
-                    .unwrap();
+            let (_, lf) = parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
+                .await
+                .unwrap();
             let shared = lf
                 .dependencies
                 .iter()
@@ -443,10 +450,9 @@ mod tests {
         let max_in_flight = resolver.max_in_flight.clone();
         let resolver = Arc::new(resolver);
 
-        let (_, lf) =
-            parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 8)
-                .await
-                .unwrap();
+        let (_, lf) = parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 8)
+            .await
+            .unwrap();
         assert_eq!(lf.dependencies.len(), 3);
         assert_eq!(in_flight.load(Ordering::SeqCst), 0);
         assert_eq!(

--- a/src/fetch/parallel.rs
+++ b/src/fetch/parallel.rs
@@ -127,8 +127,11 @@ where
             }
             let mut out = Vec::with_capacity(handles.len());
             for h in handles {
-                out.push(h.join().map_err(|_| {
-                    FetchError::Resolver(anyhow::anyhow!("worker thread panicked"))
+                out.push(h.join().map_err(|payload| {
+                    FetchError::Resolver(anyhow::anyhow!(
+                        "worker thread panicked: {}",
+                        crate::sync::panic_payload_to_string(payload)
+                    ))
                 })??);
             }
             Ok::<_, FetchError>(out)

--- a/src/fetch/parallel.rs
+++ b/src/fetch/parallel.rs
@@ -1,0 +1,403 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+
+use log::{info, warn};
+use tokio::{sync::Semaphore, task::JoinSet};
+
+use crate::{
+    fetch::FetchError,
+    git::coord_locks::CoordinateLocks,
+    model::protofetch::{
+        lock::{LockFile, LockedCoordinate, LockedDependency},
+        resolved::{ResolvedDependency, ResolvedModule},
+        Dependency, Descriptor, ModuleName, RevisionSpecification,
+    },
+    resolver::{CommitAndDescriptor, ModuleResolver},
+};
+
+/// Tunables for the parallel resolver / fetcher.
+#[derive(Debug, Clone, Copy)]
+pub struct ParallelConfig {
+    /// Maximum number of in-flight network operations (resolve / fetch).
+    pub network_jobs: usize,
+    /// Maximum number of in-flight disk-bound operations (worktree + copy).
+    pub copy_jobs: usize,
+}
+
+impl Default for ParallelConfig {
+    fn default() -> Self {
+        let cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4);
+        Self {
+            network_jobs: 16,
+            copy_jobs: (cpus / 2).max(4),
+        }
+    }
+}
+
+/// Run dependency resolution in parallel, fanning out across the blocking
+/// pool. Behavior matches the sequential resolver in [`crate::fetch::resolve`]:
+/// the same `ModuleName` resolved twice keeps the first occurrence and a
+/// warning is logged for any conflicting coordinate or revision specification.
+///
+/// `network_jobs` caps the number of concurrent resolver invocations.
+/// `coord_locks` serializes calls hitting the same on-disk bare repo.
+pub async fn parallel_resolve<R>(
+    descriptor: &Descriptor,
+    resolver: Arc<R>,
+    coord_locks: CoordinateLocks,
+    network_jobs: usize,
+) -> Result<(ResolvedModule, LockFile), FetchError>
+where
+    R: ModuleResolver + ?Sized + 'static,
+{
+    let net_sem = Arc::new(Semaphore::new(network_jobs.max(1)));
+    let mut set = JoinSet::new();
+
+    // Per-name dedup: tracks the (coord, spec) we first saw for a name so we
+    // can match the sequential implementation's "first wins + warn" semantics.
+    let mut seen: HashMap<ModuleName, (LockedCoordinate, RevisionSpecification)> = HashMap::new();
+    let mut results: BTreeMap<ModuleName, (LockedDependency, ResolvedDependency)> = BTreeMap::new();
+
+    let mut to_schedule: Vec<Dependency> = descriptor.dependencies.clone();
+    let consider_dependency =
+        |dep: Dependency,
+         seen: &mut HashMap<ModuleName, (LockedCoordinate, RevisionSpecification)>|
+         -> Option<Dependency> {
+            let locked_coord = LockedCoordinate::from(&dep.coordinate);
+            match seen.get(&dep.name) {
+                None => {
+                    seen.insert(dep.name.clone(), (locked_coord, dep.specification.clone()));
+                    Some(dep)
+                }
+                Some((existing_coord, existing_spec)) => {
+                    if existing_coord != &locked_coord {
+                        warn!(
+                            "discarded {} in favor of {} for {}",
+                            dep.coordinate, existing_coord, &dep.name
+                        );
+                    } else if existing_spec != &dep.specification {
+                        warn!(
+                            "discarded {} in favor of {} for {}",
+                            dep.specification, existing_spec, &dep.name
+                        );
+                    }
+                    None
+                }
+            }
+        };
+
+    fn spawn_resolve<R>(
+        set: &mut JoinSet<Result<(Dependency, CommitAndDescriptor), FetchError>>,
+        net_sem: &Arc<Semaphore>,
+        coord_locks: &CoordinateLocks,
+        resolver: &Arc<R>,
+        dep: Dependency,
+    ) where
+        R: ModuleResolver + ?Sized + 'static,
+    {
+        let net_sem = net_sem.clone();
+        let coord_lock = coord_locks.lock_for(&dep.coordinate);
+        let resolver = resolver.clone();
+        set.spawn(async move {
+            let permit = net_sem
+                .acquire_owned()
+                .await
+                .expect("network semaphore closed");
+            let dep_for_blocking = dep.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let _permit = permit;
+                let _g = coord_lock.lock().expect("coord lock poisoned");
+                info!("Resolving {}", dep_for_blocking.coordinate);
+                resolver.resolve(
+                    &dep_for_blocking.coordinate,
+                    &dep_for_blocking.specification,
+                    None,
+                    &dep_for_blocking.name,
+                )
+            })
+            .await
+            .map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))?
+            .map_err(FetchError::Resolver)?;
+            Ok((dep, result))
+        });
+    }
+
+    for dep in to_schedule.drain(..) {
+        if let Some(dep) = consider_dependency(dep, &mut seen) {
+            spawn_resolve(&mut set, &net_sem, &coord_locks, &resolver, dep);
+        }
+    }
+
+    while let Some(joined) = set.join_next().await {
+        let (dep, cd) = joined.map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))??;
+        let CommitAndDescriptor {
+            commit_hash,
+            descriptor: dep_descriptor,
+        } = cd;
+
+        let locked = LockedDependency {
+            name: dep.name.clone(),
+            commit_hash: commit_hash.clone(),
+            coordinate: LockedCoordinate::from(&dep.coordinate),
+            specification: dep.specification.clone(),
+        };
+        let resolved = ResolvedDependency {
+            name: dep.name.clone(),
+            commit_hash,
+            coordinate: dep.coordinate.clone(),
+            specification: dep.specification.clone(),
+            rules: dep.rules.clone(),
+            dependencies: dep_descriptor
+                .dependencies
+                .iter()
+                .map(|d| d.name.clone())
+                .collect(),
+        };
+        results.insert(dep.name.clone(), (locked, resolved));
+
+        for child in dep_descriptor.dependencies {
+            if let Some(child) = consider_dependency(child, &mut seen) {
+                spawn_resolve(&mut set, &net_sem, &coord_locks, &resolver, child);
+            }
+        }
+    }
+
+    let (locked, resolved): (Vec<_>, Vec<_>) = results.into_values().unzip();
+    let resolved = ResolvedModule {
+        module_name: descriptor.name.clone(),
+        dependencies: resolved,
+    };
+    let lockfile = LockFile {
+        dependencies: locked,
+    };
+    Ok((resolved, lockfile))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeMap,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::Duration,
+    };
+
+    use anyhow::anyhow;
+
+    use crate::{
+        fetch::{parallel::parallel_resolve, resolve},
+        git::coord_locks::CoordinateLocks,
+        model::protofetch::{
+            lock::{LockedCoordinate, LockedDependency},
+            Coordinate, Dependency, Descriptor, ModuleName, Revision, RevisionSpecification, Rules,
+        },
+        resolver::{CommitAndDescriptor, ModuleResolver},
+    };
+
+    struct FakeResolver {
+        entries: BTreeMap<Coordinate, BTreeMap<RevisionSpecification, CommitAndDescriptor>>,
+        delay_ms: u64,
+        in_flight: Arc<AtomicUsize>,
+        max_in_flight: Arc<AtomicUsize>,
+    }
+
+    impl ModuleResolver for FakeResolver {
+        fn resolve(
+            &self,
+            coordinate: &Coordinate,
+            specification: &RevisionSpecification,
+            _: Option<&str>,
+            _: &ModuleName,
+        ) -> anyhow::Result<CommitAndDescriptor> {
+            let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_in_flight.fetch_max(now, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(self.delay_ms));
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            Ok(self
+                .entries
+                .get(coordinate)
+                .ok_or_else(|| anyhow!("Coordinate not found: {}", coordinate))?
+                .get(specification)
+                .ok_or_else(|| anyhow!("Specification not found: {}", specification))?
+                .clone())
+        }
+    }
+
+    fn coord(name: &str) -> Coordinate {
+        Coordinate::from_url(&format!("example.com/org/{}", name)).unwrap()
+    }
+
+    fn dep(name: &str, revision: &str) -> Dependency {
+        Dependency {
+            name: ModuleName::from(name),
+            coordinate: coord(name),
+            specification: RevisionSpecification {
+                revision: Revision::pinned(revision),
+                branch: None,
+            },
+            rules: Rules::default(),
+        }
+    }
+
+    fn locked(name: &str, revision: &str, hash: &str) -> LockedDependency {
+        LockedDependency {
+            name: ModuleName::from(name),
+            coordinate: LockedCoordinate {
+                url: format!("example.com/org/{}", name),
+                protocol: None,
+            },
+            specification: RevisionSpecification {
+                revision: Revision::pinned(revision),
+                branch: None,
+            },
+            commit_hash: hash.to_owned(),
+        }
+    }
+
+    fn build_resolver_with(deps: &[(&str, &str, &str, Vec<Dependency>)]) -> FakeResolver {
+        let mut entries: BTreeMap<Coordinate, BTreeMap<RevisionSpecification, CommitAndDescriptor>> =
+            BTreeMap::new();
+        for (name, rev, hash, child_deps) in deps {
+            entries.entry(coord(name)).or_default().insert(
+                RevisionSpecification {
+                    revision: Revision::pinned(*rev),
+                    branch: None,
+                },
+                CommitAndDescriptor {
+                    commit_hash: hash.to_string(),
+                    descriptor: Descriptor {
+                        name: ModuleName::from(*name),
+                        description: None,
+                        proto_out_dir: None,
+                        dependencies: child_deps.clone(),
+                    },
+                },
+            );
+        }
+        FakeResolver {
+            entries,
+            delay_ms: 0,
+            in_flight: Arc::new(AtomicUsize::new(0)),
+            max_in_flight: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn matches_sequential_diamond_graph() {
+        let entries = [
+            ("foo", "1.0.0", "c1", vec![dep("bar", "2.0.0")]),
+            ("bar", "2.0.0", "c2", Vec::new()),
+        ];
+        let descriptor = Descriptor {
+            name: ModuleName::from("root"),
+            description: None,
+            proto_out_dir: None,
+            dependencies: vec![dep("foo", "1.0.0")],
+        };
+        let resolver = build_resolver_with(&entries);
+        let (_, sequential) = resolve(&descriptor, &resolver).unwrap();
+
+        let resolver = Arc::new(build_resolver_with(&entries));
+        let (_, parallel) =
+            parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
+                .await
+                .unwrap();
+
+        assert_eq!(parallel, sequential);
+        assert_eq!(parallel.dependencies.len(), 2);
+        assert!(parallel.dependencies.contains(&locked("bar", "2.0.0", "c2")));
+        assert!(parallel.dependencies.contains(&locked("foo", "1.0.0", "c1")));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn first_wins_when_same_name_resolves_to_different_coords() {
+        let entries = [
+            ("foo", "1.0.0", "c1", vec![dep("bar", "2.0.0")]),
+            ("bar", "1.0.0", "c3", Vec::new()),
+            ("bar", "2.0.0", "c2", Vec::new()),
+        ];
+        let descriptor = Descriptor {
+            name: ModuleName::from("root"),
+            description: None,
+            proto_out_dir: None,
+            dependencies: vec![dep("foo", "1.0.0"), dep("bar", "1.0.0")],
+        };
+        let resolver = Arc::new(build_resolver_with(&entries));
+        let (_, parallel) =
+            parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
+                .await
+                .unwrap();
+
+        assert!(parallel.dependencies.contains(&locked("bar", "1.0.0", "c3")));
+        assert!(parallel.dependencies.contains(&locked("foo", "1.0.0", "c1")));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn coordinate_lock_serializes_same_repo() {
+        // Three deps to the same coordinate. With per-coord lock, only one
+        // can be in flight at a time.
+        let entries = [
+            ("foo", "1.0.0", "c1", Vec::new()),
+            ("foo", "2.0.0", "c2", Vec::new()),
+            ("foo", "3.0.0", "c3", Vec::new()),
+        ];
+        let descriptor = Descriptor {
+            name: ModuleName::from("root"),
+            description: None,
+            proto_out_dir: None,
+            dependencies: vec![
+                Dependency {
+                    name: ModuleName::from("foo-a"),
+                    coordinate: coord("foo"),
+                    specification: RevisionSpecification {
+                        revision: Revision::pinned("1.0.0"),
+                        branch: None,
+                    },
+                    rules: Rules::default(),
+                },
+                Dependency {
+                    name: ModuleName::from("foo-b"),
+                    coordinate: coord("foo"),
+                    specification: RevisionSpecification {
+                        revision: Revision::pinned("2.0.0"),
+                        branch: None,
+                    },
+                    rules: Rules::default(),
+                },
+                Dependency {
+                    name: ModuleName::from("foo-c"),
+                    coordinate: coord("foo"),
+                    specification: RevisionSpecification {
+                        revision: Revision::pinned("3.0.0"),
+                        branch: None,
+                    },
+                    rules: Rules::default(),
+                },
+            ],
+        };
+
+        let mut resolver = build_resolver_with(&entries);
+        resolver.delay_ms = 30;
+        let in_flight = resolver.in_flight.clone();
+        let max_in_flight = resolver.max_in_flight.clone();
+        let resolver = Arc::new(resolver);
+
+        let (_, lf) =
+            parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 8)
+                .await
+                .unwrap();
+        assert_eq!(lf.dependencies.len(), 3);
+        assert_eq!(in_flight.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            max_in_flight.load(Ordering::SeqCst),
+            1,
+            "per-coord lock should serialize same-coord resolves"
+        );
+    }
+}

--- a/src/fetch/parallel.rs
+++ b/src/fetch/parallel.rs
@@ -1,10 +1,10 @@
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
+    thread,
 };
 
 use log::{info, warn};
-use tokio::{sync::Semaphore, task::JoinSet};
 
 use crate::{
     fetch::FetchError,
@@ -15,6 +15,7 @@ use crate::{
         Dependency, Descriptor, ModuleName, RevisionSpecification,
     },
     resolver::{CommitAndDescriptor, ModuleResolver},
+    sync::Semaphore,
 };
 
 /// Tunables for the parallel resolver / fetcher.
@@ -38,17 +39,17 @@ impl Default for ParallelConfig {
     }
 }
 
-/// Run dependency resolution in parallel, level-by-level BFS over the
-/// dep graph. Within one level, sibling deps are resolved concurrently;
-/// between levels we wait for all in-flight tasks before scheduling the
-/// next level so the per-name dedup is deterministic and matches the
-/// sequential resolver's "first wins + warn" semantics: at each level
-/// deps are considered in declaration order (parent's order, then each
-/// parent's children in declaration order).
+/// Run dependency resolution in parallel, level-by-level BFS over the dep
+/// graph. Within one level, sibling deps are resolved concurrently under
+/// the network semaphore; between levels we wait for all in-flight tasks
+/// before scheduling the next level so the per-name dedup is deterministic
+/// and matches the sequential resolver's "first wins + warn" semantics:
+/// at each level deps are considered in declaration order (parent's order,
+/// then each parent's children in declaration order).
 ///
 /// `network_jobs` caps the number of concurrent resolver invocations.
 /// `coord_locks` serializes calls hitting the same on-disk bare repo.
-pub async fn parallel_resolve<R>(
+pub fn parallel_resolve<R>(
     descriptor: &Descriptor,
     resolver: Arc<R>,
     coord_locks: CoordinateLocks,
@@ -57,7 +58,7 @@ pub async fn parallel_resolve<R>(
 where
     R: ModuleResolver + ?Sized + 'static,
 {
-    let net_sem = Arc::new(Semaphore::new(network_jobs.max(1)));
+    let net_sem = Semaphore::new(network_jobs.max(1));
 
     // Per-name dedup: tracks the (coord, spec) we first saw for a name so we
     // can match the sequential implementation's "first wins + warn" semantics.
@@ -103,43 +104,39 @@ where
             }
         }
 
-        let mut set: JoinSet<Result<(usize, Dependency, CommitAndDescriptor), FetchError>> =
-            JoinSet::new();
-        for (idx, dep) in to_schedule {
-            let net_sem = net_sem.clone();
-            let coord_lock = coord_locks.lock_for(&dep.coordinate);
-            let resolver = resolver.clone();
-            set.spawn(async move {
-                let permit = net_sem
-                    .acquire_owned()
-                    .await
-                    .expect("network semaphore closed");
-                let dep_for_blocking = dep.clone();
-                let result = tokio::task::spawn_blocking(move || {
-                    let _permit = permit;
-                    let _g = coord_lock.lock().expect("coord lock poisoned");
-                    info!("Resolving {}", dep_for_blocking.coordinate);
-                    resolver.resolve(
-                        &dep_for_blocking.coordinate,
-                        &dep_for_blocking.specification,
-                        None,
-                        &dep_for_blocking.name,
-                    )
-                })
-                .await
-                .map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))?
-                .map_err(FetchError::Resolver)?;
-                Ok((idx, dep, result))
-            });
-        }
+        // Run this level's tasks concurrently, but wait for all of them
+        // before moving on. `thread::scope` joins every spawned thread when
+        // the closure returns, so no Arc gymnastics are needed.
+        let completed: Vec<(usize, Dependency, CommitAndDescriptor)> = thread::scope(|s| {
+            let mut handles = Vec::with_capacity(to_schedule.len());
+            for (idx, dep) in to_schedule {
+                let net_sem = &net_sem;
+                let coord_lock = coord_locks.lock_for(&dep.coordinate);
+                let resolver = resolver.clone();
+                handles.push(s.spawn(
+                    move || -> Result<(usize, Dependency, CommitAndDescriptor), FetchError> {
+                        let _permit = net_sem.acquire();
+                        let _g = coord_lock.lock().expect("coord lock poisoned");
+                        info!("Resolving {}", dep.coordinate);
+                        let result = resolver
+                            .resolve(&dep.coordinate, &dep.specification, None, &dep.name)
+                            .map_err(FetchError::Resolver)?;
+                        Ok((idx, dep, result))
+                    },
+                ));
+            }
+            let mut out = Vec::with_capacity(handles.len());
+            for h in handles {
+                out.push(h.join().map_err(|_| {
+                    FetchError::Resolver(anyhow::anyhow!("worker thread panicked"))
+                })??);
+            }
+            Ok::<_, FetchError>(out)
+        })?;
 
-        // Collect results, then sort by schedule index so the next level's
-        // children appear in declaration order (parent1's children first,
-        // parent2's next, etc.).
-        let mut completed: Vec<(usize, Dependency, CommitAndDescriptor)> = Vec::new();
-        while let Some(joined) = set.join_next().await {
-            completed.push(joined.map_err(|e| FetchError::Resolver(anyhow::anyhow!(e)))??);
-        }
+        // Sort by schedule index so the next level's children appear in
+        // declaration order (parent1's children first, parent2's next, etc.).
+        let mut completed = completed;
         completed.sort_by_key(|(i, _, _)| *i);
 
         for (_, dep, cd) in completed {
@@ -296,8 +293,8 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn matches_sequential_diamond_graph() {
+    #[test]
+    fn matches_sequential_diamond_graph() {
         let entries = [
             ("foo", "1.0.0", "c1", vec![dep("bar", "2.0.0")]),
             ("bar", "2.0.0", "c2", Vec::new()),
@@ -312,9 +309,8 @@ mod tests {
         let (_, sequential) = resolve(&descriptor, &resolver).unwrap();
 
         let resolver = Arc::new(build_resolver_with(&entries));
-        let (_, parallel) = parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
-            .await
-            .unwrap();
+        let (_, parallel) =
+            parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4).unwrap();
 
         assert_eq!(parallel, sequential);
         assert_eq!(parallel.dependencies.len(), 2);
@@ -326,8 +322,8 @@ mod tests {
             .contains(&locked("foo", "1.0.0", "c1")));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn first_wins_when_same_name_resolves_to_different_coords() {
+    #[test]
+    fn first_wins_when_same_name_resolves_to_different_coords() {
         let entries = [
             ("foo", "1.0.0", "c1", vec![dep("bar", "2.0.0")]),
             ("bar", "1.0.0", "c3", Vec::new()),
@@ -340,9 +336,8 @@ mod tests {
             dependencies: vec![dep("foo", "1.0.0"), dep("bar", "1.0.0")],
         };
         let resolver = Arc::new(build_resolver_with(&entries));
-        let (_, parallel) = parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
-            .await
-            .unwrap();
+        let (_, parallel) =
+            parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4).unwrap();
 
         assert!(parallel
             .dependencies
@@ -352,8 +347,8 @@ mod tests {
             .contains(&locked("foo", "1.0.0", "c1")));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn transitive_conflicts_dedupe_in_declaration_order() {
+    #[test]
+    fn transitive_conflicts_dedupe_in_declaration_order() {
         // Regression test: two parents at level 0 each pull a child named
         // "shared" but at different coords. Whichever parent appears first in
         // the descriptor must win, regardless of which task completes first.
@@ -388,9 +383,8 @@ mod tests {
         // child even though scheduling order can flap under load.
         for _ in 0..30 {
             let resolver = Arc::new(build_resolver_with(&entries));
-            let (_, lf) = parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4)
-                .await
-                .unwrap();
+            let (_, lf) =
+                parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 4).unwrap();
             let shared = lf
                 .dependencies
                 .iter()
@@ -400,8 +394,8 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn coordinate_lock_serializes_same_repo() {
+    #[test]
+    fn coordinate_lock_serializes_same_repo() {
         // Three deps to the same coordinate. With per-coord lock, only one
         // can be in flight at a time.
         let entries = [
@@ -450,9 +444,8 @@ mod tests {
         let max_in_flight = resolver.max_in_flight.clone();
         let resolver = Arc::new(resolver);
 
-        let (_, lf) = parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 8)
-            .await
-            .unwrap();
+        let (_, lf) =
+            parallel_resolve(&descriptor, resolver, CoordinateLocks::default(), 8).unwrap();
         assert_eq!(lf.dependencies.len(), 3);
         assert_eq!(in_flight.load(Ordering::SeqCst), 0);
         assert_eq!(

--- a/src/fetch/parallel.rs
+++ b/src/fetch/parallel.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeMap, HashMap},
-    sync::Arc,
     thread,
 };
 
@@ -51,12 +50,12 @@ impl Default for ParallelConfig {
 /// `coord_locks` serializes calls hitting the same on-disk bare repo.
 pub fn parallel_resolve<R>(
     descriptor: &Descriptor,
-    resolver: Arc<R>,
+    resolver: R,
     coord_locks: CoordinateLocks,
     network_jobs: usize,
 ) -> Result<(ResolvedModule, LockFile), FetchError>
 where
-    R: ModuleResolver + ?Sized + 'static,
+    R: ModuleResolver + Clone + 'static,
 {
     let net_sem = Semaphore::new(network_jobs.max(1));
 
@@ -127,12 +126,10 @@ where
             }
             let mut out = Vec::with_capacity(handles.len());
             for h in handles {
-                out.push(h.join().map_err(|payload| {
-                    FetchError::Resolver(anyhow::anyhow!(
-                        "worker thread panicked: {}",
-                        crate::sync::panic_payload_to_string(payload)
-                    ))
-                })??);
+                match h.join() {
+                    Ok(result) => out.push(result?),
+                    Err(payload) => std::panic::resume_unwind(payload),
+                }
             }
             Ok::<_, FetchError>(out)
         })?;
@@ -197,7 +194,7 @@ mod tests {
     use anyhow::anyhow;
 
     use crate::{
-        fetch::{parallel::parallel_resolve, resolve},
+        fetch::{parallel::parallel_resolve, tests::resolve},
         git::coord_locks::CoordinateLocks,
         model::protofetch::{
             lock::{LockedCoordinate, LockedDependency},

--- a/src/git/cache.rs
+++ b/src/git/cache.rs
@@ -244,8 +244,17 @@ fn host_matches_patterns(host: &str, patterns: &HostPatterns) -> bool {
     }
 }
 
+// `CoordinateLocks` wraps a `DashMap` whose internal `RwLock`s do not
+// implement `UnwindSafe` / `RefUnwindSafe` automatically. The map's value
+// type is `Arc<Mutex<()>>` — a dataless mutex — so a panic while a lock is
+// held cannot leave invariants broken. We therefore assert these auto-traits
+// manually to preserve the auto-trait surface that `ProtofetchGitCache` and
+// `Protofetch` exposed before the parallelism rewrite.
+impl std::panic::UnwindSafe for ProtofetchGitCache {}
+impl std::panic::RefUnwindSafe for ProtofetchGitCache {}
+
 #[allow(dead_code)]
-fn _assert_send_sync() {
-    fn assert<T: Send + Sync>() {}
+fn _assert_traits() {
+    fn assert<T: Send + Sync + std::panic::UnwindSafe + std::panic::RefUnwindSafe>() {}
     assert::<ProtofetchGitCache>();
 }

--- a/src/git/cache.rs
+++ b/src/git/cache.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 use crate::{
     flock::FileLock,
-    git::repository::ProtoGitRepository,
+    git::{coord_locks::CoordinateLocks, repository::ProtoGitRepository},
     model::protofetch::{Coordinate, Protocol},
 };
 
@@ -20,8 +20,12 @@ const GLOBAL_KNOWN_HOSTS: &str = "/etc/ssh/ssh_known_hosts";
 pub struct ProtofetchGitCache {
     location: PathBuf,
     worktrees: PathBuf,
-    git_config: Config,
+    // `git2::Config` is neither `Send` nor `Sync`, so we cannot keep one on the
+    // cache when the cache is shared across threads. Instead each call to
+    // `fetch_options` opens a fresh default config, which only inspects the
+    // user/system git config files and is cheap.
     default_protocol: Protocol,
+    coord_locks: CoordinateLocks,
     _lock: FileLock,
 }
 
@@ -40,7 +44,6 @@ pub enum CacheError {
 impl ProtofetchGitCache {
     pub fn new(
         location: PathBuf,
-        git_config: Config,
         default_protocol: Protocol,
     ) -> Result<ProtofetchGitCache, CacheError> {
         if location.exists() {
@@ -59,10 +62,14 @@ impl ProtofetchGitCache {
         Ok(ProtofetchGitCache {
             location,
             worktrees,
-            git_config,
             default_protocol,
+            coord_locks: CoordinateLocks::default(),
             _lock: lock,
         })
+    }
+
+    pub fn coord_locks(&self) -> &CoordinateLocks {
+        &self.coord_locks
     }
 
     pub fn clear(&self) -> anyhow::Result<()> {
@@ -142,6 +149,10 @@ impl ProtofetchGitCache {
         let mut tried_username = false;
         let mut tried_agent = false;
         let mut tried_helper = false;
+        // `git2::Config` is `!Send` and `!Sync`, so we open a fresh per-call
+        // copy and let the credentials closure own it for the duration of the
+        // fetch.
+        let git_config = Config::open_default()?;
 
         // Consider using https://crates.io/crates/git2_credentials that supports
         // more authentication options
@@ -165,7 +176,7 @@ impl ProtofetchGitCache {
             // HTTP auth
             if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) && !tried_helper {
                 tried_helper = true;
-                return Cred::credential_helper(&self.git_config, url, username);
+                return Cred::credential_helper(&git_config, url, username);
             }
             Err(git2::Error::from_str("no valid authentication available"))
         });
@@ -231,4 +242,10 @@ fn host_matches_patterns(host: &str, patterns: &HostPatterns) -> bool {
         // Not yet supported
         HostPatterns::HashedName { .. } => false,
     }
+}
+
+#[allow(dead_code)]
+fn _assert_send_sync() {
+    fn assert<T: Send + Sync>() {}
+    assert::<ProtofetchGitCache>();
 }

--- a/src/git/cache.rs
+++ b/src/git/cache.rs
@@ -20,10 +20,6 @@ const GLOBAL_KNOWN_HOSTS: &str = "/etc/ssh/ssh_known_hosts";
 pub struct ProtofetchGitCache {
     location: PathBuf,
     worktrees: PathBuf,
-    // `git2::Config` is neither `Send` nor `Sync`, so we cannot keep one on the
-    // cache when the cache is shared across threads. Instead each call to
-    // `fetch_options` opens a fresh default config, which only inspects the
-    // user/system git config files and is cheap.
     default_protocol: Protocol,
     coord_locks: CoordinateLocks,
     _lock: FileLock,
@@ -243,15 +239,6 @@ fn host_matches_patterns(host: &str, patterns: &HostPatterns) -> bool {
         HostPatterns::HashedName { .. } => false,
     }
 }
-
-// `CoordinateLocks` wraps a `DashMap` whose internal `RwLock`s do not
-// implement `UnwindSafe` / `RefUnwindSafe` automatically. The map's value
-// type is `Arc<Mutex<()>>` — a dataless mutex — so a panic while a lock is
-// held cannot leave invariants broken. We therefore assert these auto-traits
-// manually to preserve the auto-trait surface that `ProtofetchGitCache` and
-// `Protofetch` exposed before the parallelism rewrite.
-impl std::panic::UnwindSafe for ProtofetchGitCache {}
-impl std::panic::RefUnwindSafe for ProtofetchGitCache {}
 
 #[allow(dead_code)]
 fn _assert_traits() {

--- a/src/git/coord_locks.rs
+++ b/src/git/coord_locks.rs
@@ -1,0 +1,70 @@
+use std::sync::{Arc, Mutex};
+
+use dashmap::DashMap;
+
+use crate::model::protofetch::Coordinate;
+
+/// A map of per-coordinate locks. libgit2 is per-`Repository` thread-safe, but
+/// concurrent fetches or worktree-add calls into the same on-disk bare repo can
+/// race on ref updates. Acquiring the same `Mutex` per coordinate serializes
+/// operations on one repo while still allowing different repos to run in
+/// parallel.
+#[derive(Default, Clone)]
+pub struct CoordinateLocks {
+    inner: Arc<DashMap<Coordinate, Arc<Mutex<()>>>>,
+}
+
+impl CoordinateLocks {
+    pub fn lock_for(&self, coord: &Coordinate) -> Arc<Mutex<()>> {
+        self.inner
+            .entry(coord.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, thread};
+
+    use crate::model::protofetch::Coordinate;
+
+    use super::CoordinateLocks;
+
+    fn coord(name: &str) -> Coordinate {
+        Coordinate::from_url(&format!("example.com/org/{}", name)).unwrap()
+    }
+
+    #[test]
+    fn same_coord_returns_same_lock() {
+        let locks = CoordinateLocks::default();
+        let a = locks.lock_for(&coord("foo"));
+        let b = locks.lock_for(&coord("foo"));
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn different_coords_return_different_locks() {
+        let locks = CoordinateLocks::default();
+        let a = locks.lock_for(&coord("foo"));
+        let b = locks.lock_for(&coord("bar"));
+        assert!(!Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn concurrent_lock_for_does_not_panic() {
+        let locks = CoordinateLocks::default();
+        let mut handles = Vec::new();
+        for i in 0..32 {
+            let locks = locks.clone();
+            handles.push(thread::spawn(move || {
+                for _ in 0..50 {
+                    let _l = locks.lock_for(&coord(&format!("dep{}", i % 4)));
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+}

--- a/src/git/coord_locks.rs
+++ b/src/git/coord_locks.rs
@@ -1,21 +1,26 @@
 use std::{
     collections::HashMap,
+    path::PathBuf,
     sync::{Arc, Mutex},
 };
 
 use crate::model::protofetch::Coordinate;
 
-/// A map of per-coordinate locks. libgit2 is per-`Repository` thread-safe, but
-/// concurrent fetches or worktree-add calls into the same on-disk bare repo can
-/// race on ref updates. Acquiring the same `Mutex` per coordinate serializes
-/// operations on one repo while still allowing different repos to run in
-/// parallel.
+/// A map of per-repo locks. libgit2 is per-`Repository` thread-safe, but
+/// concurrent fetches or worktree-add calls into the same on-disk bare repo
+/// can race on ref updates. Acquiring the same `Mutex` per `forge/org/repo`
+/// path serializes operations on one repo while still allowing different
+/// repos to run in parallel.
+///
+/// The key intentionally ignores `protocol`: two coordinates that differ
+/// only in `https` vs `ssh` resolve to the same on-disk bare repo, and so
+/// must share a lock.
 ///
 /// The outer `Mutex` is only held long enough to look up or insert the inner
 /// `Arc<Mutex<()>>` (microseconds), so it is not contended in practice.
 #[derive(Default, Clone)]
 pub struct CoordinateLocks {
-    inner: Arc<Mutex<HashMap<Coordinate, Arc<Mutex<()>>>>>,
+    inner: Arc<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>>,
 }
 
 impl CoordinateLocks {
@@ -23,7 +28,7 @@ impl CoordinateLocks {
         self.inner
             .lock()
             .expect("coord lock map poisoned")
-            .entry(coord.clone())
+            .entry(coord.to_path())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
     }
@@ -72,5 +77,20 @@ mod tests {
         for h in handles {
             h.join().unwrap();
         }
+    }
+
+    #[test]
+    fn same_path_different_protocol_returns_same_lock() {
+        use crate::model::protofetch::Protocol;
+
+        let mut https = Coordinate::from_url("github.com/org/repo").unwrap();
+        https.protocol = Some(Protocol::Https);
+        let mut ssh = Coordinate::from_url("github.com/org/repo").unwrap();
+        ssh.protocol = Some(Protocol::Ssh);
+
+        let locks = CoordinateLocks::default();
+        let a = locks.lock_for(&https);
+        let b = locks.lock_for(&ssh);
+        assert!(Arc::ptr_eq(&a, &b));
     }
 }

--- a/src/git/coord_locks.rs
+++ b/src/git/coord_locks.rs
@@ -1,6 +1,7 @@
-use std::sync::{Arc, Mutex};
-
-use dashmap::DashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use crate::model::protofetch::Coordinate;
 
@@ -9,14 +10,19 @@ use crate::model::protofetch::Coordinate;
 /// race on ref updates. Acquiring the same `Mutex` per coordinate serializes
 /// operations on one repo while still allowing different repos to run in
 /// parallel.
+///
+/// The outer `Mutex` is only held long enough to look up or insert the inner
+/// `Arc<Mutex<()>>` (microseconds), so it is not contended in practice.
 #[derive(Default, Clone)]
 pub struct CoordinateLocks {
-    inner: Arc<DashMap<Coordinate, Arc<Mutex<()>>>>,
+    inner: Arc<Mutex<HashMap<Coordinate, Arc<Mutex<()>>>>>,
 }
 
 impl CoordinateLocks {
     pub fn lock_for(&self, coord: &Coordinate) -> Arc<Mutex<()>> {
         self.inner
+            .lock()
+            .expect("coord lock map poisoned")
             .entry(coord.clone())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()

--- a/src/git/coord_locks.rs
+++ b/src/git/coord_locks.rs
@@ -34,6 +34,14 @@ impl CoordinateLocks {
     }
 }
 
+// The map's value type is `Arc<Mutex<()>>` — a dataless mutex — so a panic
+// while a lock is held cannot leave invariants broken. `Mutex<T>` does not
+// auto-impl `UnwindSafe` / `RefUnwindSafe`, so we provide them manually
+// here. Doing it on `CoordinateLocks` lets the auto-traits flow to
+// `ProtofetchGitCache` and `Protofetch` automatically.
+impl std::panic::UnwindSafe for CoordinateLocks {}
+impl std::panic::RefUnwindSafe for CoordinateLocks {}
+
 #[cfg(test)]
 mod tests {
     use std::{sync::Arc, thread};

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,2 +1,3 @@
 pub mod cache;
+pub mod coord_locks;
 pub mod repository;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,6 @@ mod git;
 mod model;
 mod proto;
 mod resolver;
+mod sync;
 
 pub use api::{LockMode, Protofetch, ProtofetchBuilder};

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,15 @@ pub struct CliArgs {
     /// this will override proto_out_dir from the module toml config
     #[clap(short, long)]
     pub output_proto_directory: Option<String>,
+    /// Maximum number of in-flight network jobs (resolve + fetch).
+    /// Defaults to 16; can also be set via the PROTOFETCH_JOBS env var.
+    #[clap(long, env = "PROTOFETCH_JOBS")]
+    pub jobs: Option<usize>,
+    /// Maximum number of in-flight disk jobs (worktree + copy).
+    /// Defaults to max(4, num_cpus / 2); can also be set via the
+    /// PROTOFETCH_COPY_JOBS env var.
+    #[clap(long, env = "PROTOFETCH_COPY_JOBS")]
+    pub copy_jobs: Option<usize>,
 }
 
 #[derive(Debug, Parser)]
@@ -105,6 +114,18 @@ fn run() -> Result<(), Box<dyn Error>> {
     }
     if let Some(cache_directory) = &cli_args.cache_directory {
         protofetch = protofetch.cache_directory(cache_directory);
+    }
+    if let Some(jobs) = cli_args.jobs {
+        if jobs == 0 {
+            return Err("--jobs must be at least 1".into());
+        }
+        protofetch = protofetch.jobs(jobs);
+    }
+    if let Some(copy_jobs) = cli_args.copy_jobs {
+        if copy_jobs == 0 {
+            return Err("--copy-jobs must be at least 1".into());
+        }
+        protofetch = protofetch.copy_jobs(copy_jobs);
     }
 
     match cli_args.cmd {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,14 +25,13 @@ pub struct CliArgs {
     /// this will override proto_out_dir from the module toml config
     #[clap(short, long)]
     pub output_proto_directory: Option<String>,
-    /// Maximum number of in-flight network jobs (resolve + fetch).
-    /// Defaults to 16; can also be set via the PROTOFETCH_JOBS env var.
-    #[clap(long, env = "PROTOFETCH_JOBS")]
+    /// Maximum number of in-flight network jobs (resolve + fetch). Overrides
+    /// PROTOFETCH_JOBS / config.toml. Defaults to 16.
+    #[clap(long)]
     pub jobs: Option<usize>,
-    /// Maximum number of in-flight disk jobs (worktree + copy).
-    /// Defaults to max(4, num_cpus / 2); can also be set via the
-    /// PROTOFETCH_COPY_JOBS env var.
-    #[clap(long, env = "PROTOFETCH_COPY_JOBS")]
+    /// Maximum number of in-flight disk jobs (worktree + copy). Overrides
+    /// PROTOFETCH_COPY_JOBS / config.toml. Defaults to max(4, num_cpus / 2).
+    #[clap(long)]
     pub copy_jobs: Option<usize>,
 }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -4,11 +4,11 @@ use std::{
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
     sync::Arc,
+    thread,
 };
 
 use log::{debug, info, trace};
 use thiserror::Error;
-use tokio::{sync::Semaphore, task::JoinSet};
 
 use crate::{
     cache::RepositoryCache,
@@ -17,6 +17,7 @@ use crate::{
         resolved::{ResolvedDependency, ResolvedModule},
         AllowPolicies, DenyPolicies, ModuleName,
     },
+    sync::Semaphore,
 };
 
 #[derive(Error, Debug)]
@@ -70,11 +71,11 @@ fn process_one_dep<C: RepositoryCache + ?Sized>(
     Ok(())
 }
 
-/// Concurrent equivalent of [`copy_proto_files`]. Each root dep runs as a
-/// blocking task on the runtime's blocking pool, gated by `parallel.copy_jobs`.
-/// Within one dep we keep work sequential because the recursive prune walk
-/// already shares a single per-coord lock with stage 1/2.
-pub async fn copy_proto_files_parallel<C>(
+/// Sequential per-dep work runs across `parallel.copy_jobs` worker threads
+/// gated by a disk semaphore so network and disk concurrency are tunable
+/// independently. Per-coord serialization for `create_worktree` is handled
+/// inside `process_one_dep` via the cache's `coord_locks`.
+pub fn copy_proto_files_parallel<C>(
     cache: Arc<C>,
     resolved: Arc<ResolvedModule>,
     proto_dir: PathBuf,
@@ -92,29 +93,26 @@ where
     }
 
     let deps = collect_all_root_dependencies(&resolved);
-    let disk_sem = Arc::new(Semaphore::new(parallel.copy_jobs.max(1)));
-    let mut set = JoinSet::new();
+    let disk_sem = Semaphore::new(parallel.copy_jobs.max(1));
 
-    for dep in deps {
-        let permit = disk_sem
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("disk semaphore closed");
-        let cache = cache.clone();
-        let resolved = resolved.clone();
-        let proto_dir = proto_dir.clone();
-        set.spawn_blocking(move || {
-            let _permit = permit;
-            process_one_dep(&*cache, &resolved, &proto_dir, &dep)
-        });
-    }
-
-    while let Some(joined) = set.join_next().await {
-        let outcome = joined.map_err(|e| ProtoError::Cache(anyhow::anyhow!(e)))?;
-        outcome?;
-    }
-    Ok(())
+    thread::scope(|s| -> Result<(), ProtoError> {
+        let mut handles = Vec::with_capacity(deps.len());
+        for dep in deps {
+            let cache = cache.clone();
+            let resolved = resolved.clone();
+            let proto_dir = proto_dir.clone();
+            let disk_sem = &disk_sem;
+            handles.push(s.spawn(move || {
+                let _permit = disk_sem.acquire();
+                process_one_dep(&*cache, &resolved, &proto_dir, &dep)
+            }));
+        }
+        for h in handles {
+            h.join()
+                .map_err(|_| ProtoError::Cache(anyhow::anyhow!("worker thread panicked")))??;
+        }
+        Ok(())
+    })
 }
 
 /// Copy all proto files for a dependency to the proto_dir

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -3,13 +3,16 @@ use std::{
     fs::File,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use log::{debug, info, trace};
 use thiserror::Error;
+use tokio::{sync::Semaphore, task::JoinSet};
 
 use crate::{
     cache::RepositoryCache,
+    fetch::ParallelConfig,
     model::protofetch::{
         resolved::{ResolvedDependency, ResolvedModule},
         AllowPolicies, DenyPolicies, ModuleName,
@@ -45,35 +48,71 @@ struct ProtoFileCanonicalMapping {
 /// proto_dir: Base path to the directory where the proto files are to be copied to
 /// cache_src_dir: Base path to the directory where the dependencies sources are cached
 /// lockfile: The lockfile that contains the dependencies to be copied
-pub fn copy_proto_files(
-    cache: &impl RepositoryCache,
+fn process_one_dep<C: RepositoryCache + ?Sized>(
+    cache: &C,
     resolved: &ResolvedModule,
     proto_dir: &Path,
+    dep: &ResolvedDependency,
 ) -> Result<(), ProtoError> {
+    let dep_cache_dir = cache
+        .create_worktree(&dep.coordinate, &dep.commit_hash, &dep.name)
+        .map_err(ProtoError::Cache)?;
+    let sources_to_copy: HashSet<ProtoFileMapping> = if !dep.rules.prune {
+        copy_all_proto_files_for_dep(&dep_cache_dir, dep)?
+    } else {
+        pruned_transitive_dependencies(cache, dep, resolved)?
+    };
+    let without_denied_files = sources_to_copy
+        .into_iter()
+        .filter(|m| !DenyPolicies::should_deny_file(&dep.rules.deny_policies, &m.to))
+        .collect();
+    copy_proto_sources_for_dep(proto_dir, &dep_cache_dir, dep, &without_denied_files)?;
+    Ok(())
+}
+
+/// Concurrent equivalent of [`copy_proto_files`]. Each root dep runs as a
+/// blocking task on the runtime's blocking pool, gated by `parallel.copy_jobs`.
+/// Within one dep we keep work sequential because the recursive prune walk
+/// already shares a single per-coord lock with stage 1/2.
+pub async fn copy_proto_files_parallel<C>(
+    cache: Arc<C>,
+    resolved: Arc<ResolvedModule>,
+    proto_dir: PathBuf,
+    parallel: ParallelConfig,
+) -> Result<(), ProtoError>
+where
+    C: RepositoryCache + 'static,
+{
     info!(
         "Copying proto files from {} descriptor...",
         resolved.module_name
     );
     if !proto_dir.exists() {
-        std::fs::create_dir_all(proto_dir)?;
+        std::fs::create_dir_all(&proto_dir)?;
     }
 
-    let deps = collect_all_root_dependencies(resolved);
+    let deps = collect_all_root_dependencies(&resolved);
+    let disk_sem = Arc::new(Semaphore::new(parallel.copy_jobs.max(1)));
+    let mut set = JoinSet::new();
 
-    for dep in &deps {
-        let dep_cache_dir = cache
-            .create_worktree(&dep.coordinate, &dep.commit_hash, &dep.name)
-            .map_err(ProtoError::Cache)?;
-        let sources_to_copy: HashSet<ProtoFileMapping> = if !dep.rules.prune {
-            copy_all_proto_files_for_dep(&dep_cache_dir, dep)?
-        } else {
-            pruned_transitive_dependencies(cache, dep, resolved)?
-        };
-        let without_denied_files = sources_to_copy
-            .into_iter()
-            .filter(|m| !DenyPolicies::should_deny_file(&dep.rules.deny_policies, &m.to))
-            .collect();
-        copy_proto_sources_for_dep(proto_dir, &dep_cache_dir, dep, &without_denied_files)?;
+    for dep in deps {
+        let permit = disk_sem
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("disk semaphore closed");
+        let cache = cache.clone();
+        let resolved = resolved.clone();
+        let proto_dir = proto_dir.clone();
+        set.spawn_blocking(move || {
+            let _permit = permit;
+            process_one_dep(&*cache, &resolved, &proto_dir, &dep)
+        });
+    }
+
+    while let Some(joined) = set.join_next().await {
+        let outcome = joined.map_err(|e| ProtoError::Cache(anyhow::anyhow!(e)))?;
+        outcome?;
     }
     Ok(())
 }
@@ -107,13 +146,13 @@ fn copy_all_proto_files_for_dep(
 /// Returns a HashSet of ProtoFileMapping to the proto files that `dep` depends on. It recursively
 /// iterates all the dependencies of `dep` and its transitive dependencies based on imports
 /// until no new dependencies are found.
-fn pruned_transitive_dependencies(
-    cache: &impl RepositoryCache,
+fn pruned_transitive_dependencies<C: RepositoryCache + ?Sized>(
+    cache: &C,
     dep: &ResolvedDependency,
     lockfile: &ResolvedModule,
 ) -> Result<HashSet<ProtoFileMapping>, ProtoError> {
-    fn process_mapping_file(
-        cache: &impl RepositoryCache,
+    fn process_mapping_file<C: RepositoryCache + ?Sized>(
+        cache: &C,
         mapping: ProtoFileCanonicalMapping,
         dep: &ResolvedDependency,
         lockfile: &ResolvedModule,
@@ -133,8 +172,8 @@ fn pruned_transitive_dependencies(
 
     /// Recursively loop through all the file dependencies based on imports
     /// Looks in own repository and in transitive dependencies.
-    fn inner_loop(
-        cache: &impl RepositoryCache,
+    fn inner_loop<C: RepositoryCache + ?Sized>(
+        cache: &C,
         dep: &ResolvedDependency,
         lockfile: &ResolvedModule,
         visited: &mut HashSet<PathBuf>,
@@ -346,8 +385,8 @@ fn filtered_proto_files(
 /// Takes a slice of proto files, cache source directory and a slice of dependencies associated with these files
 /// and builds the full proto file paths from the package path returning a ProtoFileCanonicalMapping.
 /// This is used to be able to later on copy the files from the source directory to the user defined output directory.
-fn canonical_mapping_for_proto_files(
-    cache: &impl RepositoryCache,
+fn canonical_mapping_for_proto_files<C: RepositoryCache + ?Sized>(
+    cache: &C,
     proto_files: &[PathBuf],
     deps: &[ResolvedDependency],
 ) -> Result<Vec<ProtoFileCanonicalMapping>, ProtoError> {
@@ -390,8 +429,8 @@ fn zoom_in_content_root(
     Ok(proto_src)
 }
 
-fn zoom_out_content_root(
-    cache: &impl RepositoryCache,
+fn zoom_out_content_root<C: RepositoryCache + ?Sized>(
+    cache: &C,
     deps: &[ResolvedDependency],
     proto_file_source: &Path,
 ) -> Result<PathBuf, ProtoError> {

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use crate::{
     cache::RepositoryCache,
     fetch::ParallelConfig,
+    git::coord_locks::CoordinateLocks,
     model::protofetch::{
         resolved::{ResolvedDependency, ResolvedModule},
         AllowPolicies, DenyPolicies, ModuleName,
@@ -73,12 +74,13 @@ fn process_one_dep<C: RepositoryCache + ?Sized>(
 
 /// Sequential per-dep work runs across `parallel.copy_jobs` worker threads
 /// gated by a disk semaphore so network and disk concurrency are tunable
-/// independently. Per-coord serialization for `create_worktree` is handled
-/// inside `process_one_dep` via the cache's `coord_locks`.
+/// independently. The per-coord lock serializes `create_worktree` calls for
+/// deps that share an on-disk bare repo.
 pub fn copy_proto_files_parallel<C>(
     cache: Arc<C>,
     resolved: Arc<ResolvedModule>,
     proto_dir: PathBuf,
+    coord_locks: CoordinateLocks,
     parallel: ParallelConfig,
 ) -> Result<(), ProtoError>
 where
@@ -102,14 +104,20 @@ where
             let resolved = resolved.clone();
             let proto_dir = proto_dir.clone();
             let disk_sem = &disk_sem;
+            let coord_lock = coord_locks.lock_for(&dep.coordinate);
             handles.push(s.spawn(move || {
                 let _permit = disk_sem.acquire();
+                let _g = coord_lock.lock().expect("coord lock poisoned");
                 process_one_dep(&*cache, &resolved, &proto_dir, &dep)
             }));
         }
         for h in handles {
-            h.join()
-                .map_err(|_| ProtoError::Cache(anyhow::anyhow!("worker thread panicked")))??;
+            h.join().map_err(|payload| {
+                ProtoError::Cache(anyhow::anyhow!(
+                    "worker thread panicked: {}",
+                    crate::sync::panic_payload_to_string(payload)
+                ))
+            })??;
         }
         Ok(())
     })

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -77,14 +77,14 @@ fn process_one_dep<C: RepositoryCache + ?Sized>(
 /// independently. The per-coord lock serializes `create_worktree` calls for
 /// deps that share an on-disk bare repo.
 pub fn copy_proto_files_parallel<C>(
-    cache: Arc<C>,
+    cache: C,
     resolved: Arc<ResolvedModule>,
     proto_dir: PathBuf,
     coord_locks: CoordinateLocks,
     parallel: ParallelConfig,
 ) -> Result<(), ProtoError>
 where
-    C: RepositoryCache + 'static,
+    C: RepositoryCache + Clone + 'static,
 {
     info!(
         "Copying proto files from {} descriptor...",
@@ -108,16 +108,14 @@ where
             handles.push(s.spawn(move || {
                 let _permit = disk_sem.acquire();
                 let _g = coord_lock.lock().expect("coord lock poisoned");
-                process_one_dep(&*cache, &resolved, &proto_dir, &dep)
+                process_one_dep(&cache, &resolved, &proto_dir, &dep)
             }));
         }
         for h in handles {
-            h.join().map_err(|payload| {
-                ProtoError::Cache(anyhow::anyhow!(
-                    "worker thread panicked: {}",
-                    crate::sync::panic_payload_to_string(payload)
-                ))
-            })??;
+            match h.join() {
+                Ok(result) => result?,
+                Err(payload) => std::panic::resume_unwind(payload),
+            }
         }
         Ok(())
     })

--- a/src/resolver/lock.rs
+++ b/src/resolver/lock.rs
@@ -8,14 +8,14 @@ use crate::model::protofetch::{
 
 use super::{CommitAndDescriptor, ModuleResolver};
 
-pub struct LockFileModuleResolver<'a, R> {
+pub struct LockFileModuleResolver<R> {
     inner: R,
-    lock_file: &'a LockFile,
+    lock_file: LockFile,
     locked: bool,
 }
 
-impl<'a, R> LockFileModuleResolver<'a, R> {
-    pub fn new(inner: R, lock_file: &'a LockFile, locked: bool) -> Self {
+impl<R> LockFileModuleResolver<R> {
+    pub fn new(inner: R, lock_file: LockFile, locked: bool) -> Self {
         Self {
             inner,
             lock_file,
@@ -24,7 +24,7 @@ impl<'a, R> LockFileModuleResolver<'a, R> {
     }
 }
 
-impl<R> ModuleResolver for LockFileModuleResolver<'_, R>
+impl<R> ModuleResolver for LockFileModuleResolver<R>
 where
     R: ModuleResolver,
 {

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1,11 +1,13 @@
 mod git;
 mod lock;
 
+use std::sync::Arc;
+
 use crate::model::protofetch::{Coordinate, Descriptor, ModuleName, RevisionSpecification};
 
 pub use lock::LockFileModuleResolver;
 
-pub trait ModuleResolver {
+pub trait ModuleResolver: Send + Sync {
     fn resolve(
         &self,
         coordinate: &Coordinate,
@@ -23,7 +25,22 @@ pub struct CommitAndDescriptor {
 
 impl<T> ModuleResolver for &T
 where
-    T: ModuleResolver,
+    T: ModuleResolver + ?Sized,
+{
+    fn resolve(
+        &self,
+        coordinate: &Coordinate,
+        specification: &RevisionSpecification,
+        commit_hash: Option<&str>,
+        name: &ModuleName,
+    ) -> anyhow::Result<CommitAndDescriptor> {
+        T::resolve(self, coordinate, specification, commit_hash, name)
+    }
+}
+
+impl<T> ModuleResolver for Arc<T>
+where
+    T: ModuleResolver + ?Sized,
 {
     fn resolve(
         &self,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,0 +1,91 @@
+//! Small synchronization primitives used by the parallel fetcher. These
+//! exist so the crate doesn't need an async runtime just to coordinate
+//! N concurrent libgit2 calls behind a concurrency cap.
+
+use std::sync::{Condvar, Mutex};
+
+/// Counting semaphore. Threads call [`acquire`] and block until a permit
+/// is available; the returned [`Permit`] releases the permit on drop.
+pub struct Semaphore {
+    permits: Mutex<usize>,
+    cv: Condvar,
+}
+
+impl Semaphore {
+    pub fn new(permits: usize) -> Self {
+        Self {
+            permits: Mutex::new(permits),
+            cv: Condvar::new(),
+        }
+    }
+
+    pub fn acquire(&self) -> Permit<'_> {
+        let mut g = self.permits.lock().expect("semaphore poisoned");
+        while *g == 0 {
+            g = self.cv.wait(g).expect("semaphore poisoned");
+        }
+        *g -= 1;
+        Permit { sem: self }
+    }
+}
+
+pub struct Permit<'a> {
+    sem: &'a Semaphore,
+}
+
+impl Drop for Permit<'_> {
+    fn drop(&mut self) {
+        let mut g = self.sem.permits.lock().expect("semaphore poisoned");
+        *g += 1;
+        self.sem.cv.notify_one();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        thread,
+        time::Duration,
+    };
+
+    use super::Semaphore;
+
+    #[test]
+    fn permits_are_returned_on_drop() {
+        let sem = Semaphore::new(2);
+        let p1 = sem.acquire();
+        let p2 = sem.acquire();
+        drop(p1);
+        let _p3 = sem.acquire(); // would block forever if drop didn't return
+        drop(p2);
+    }
+
+    #[test]
+    fn caps_concurrent_acquirers() {
+        let sem = Arc::new(Semaphore::new(2));
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+
+        thread::scope(|s| {
+            for _ in 0..16 {
+                let sem = sem.clone();
+                let in_flight = in_flight.clone();
+                let max_in_flight = max_in_flight.clone();
+                s.spawn(move || {
+                    let _permit = sem.acquire();
+                    let now = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_in_flight.fetch_max(now, Ordering::SeqCst);
+                    thread::sleep(Duration::from_millis(20));
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                });
+            }
+        });
+
+        assert_eq!(in_flight.load(Ordering::SeqCst), 0);
+        assert_eq!(max_in_flight.load(Ordering::SeqCst), 2);
+    }
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,6 +2,7 @@
 //! exist so the crate doesn't need an async runtime just to coordinate
 //! N concurrent libgit2 calls behind a concurrency cap.
 
+use std::any::Any;
 use std::sync::{Condvar, Mutex};
 
 /// Counting semaphore. Threads call [`acquire`] and block until a permit
@@ -41,6 +42,19 @@ impl Drop for Permit<'_> {
     }
 }
 
+/// Convert a panic payload (the `Err` value of `JoinHandle::join`) into a
+/// printable string. Tries the two common panic payload types
+/// (`&'static str` and `String`) before falling back to a placeholder.
+pub fn panic_payload_to_string(payload: Box<dyn Any + Send + 'static>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "<non-string panic payload>".to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -53,6 +67,30 @@ mod tests {
     };
 
     use super::Semaphore;
+
+    #[test]
+    fn payload_extraction_string_literal() {
+        let h = thread::spawn(|| panic!("boom"));
+        let err = h.join().unwrap_err();
+        assert_eq!(super::panic_payload_to_string(err), "boom");
+    }
+
+    #[test]
+    fn payload_extraction_owned_string() {
+        let h = thread::spawn(|| panic!("dynamic: {}", 42));
+        let err = h.join().unwrap_err();
+        assert_eq!(super::panic_payload_to_string(err), "dynamic: 42");
+    }
+
+    #[test]
+    fn payload_extraction_non_string_fallback() {
+        let h = thread::spawn(|| std::panic::panic_any(123u32));
+        let err = h.join().unwrap_err();
+        assert_eq!(
+            super::panic_payload_to_string(err),
+            "<non-string panic payload>"
+        );
+    }
 
     #[test]
     fn permits_are_returned_on_drop() {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,7 +2,6 @@
 //! exist so the crate doesn't need an async runtime just to coordinate
 //! N concurrent libgit2 calls behind a concurrency cap.
 
-use std::any::Any;
 use std::sync::{Condvar, Mutex};
 
 /// Counting semaphore. Threads call [`acquire`] and block until a permit
@@ -42,19 +41,6 @@ impl Drop for Permit<'_> {
     }
 }
 
-/// Convert a panic payload (the `Err` value of `JoinHandle::join`) into a
-/// printable string. Tries the two common panic payload types
-/// (`&'static str` and `String`) before falling back to a placeholder.
-pub fn panic_payload_to_string(payload: Box<dyn Any + Send + 'static>) -> String {
-    if let Some(s) = payload.downcast_ref::<&'static str>() {
-        return (*s).to_string();
-    }
-    if let Some(s) = payload.downcast_ref::<String>() {
-        return s.clone();
-    }
-    "<non-string panic payload>".to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
@@ -67,30 +53,6 @@ mod tests {
     };
 
     use super::Semaphore;
-
-    #[test]
-    fn payload_extraction_string_literal() {
-        let h = thread::spawn(|| panic!("boom"));
-        let err = h.join().unwrap_err();
-        assert_eq!(super::panic_payload_to_string(err), "boom");
-    }
-
-    #[test]
-    fn payload_extraction_owned_string() {
-        let h = thread::spawn(|| panic!("dynamic: {}", 42));
-        let err = h.join().unwrap_err();
-        assert_eq!(super::panic_payload_to_string(err), "dynamic: 42");
-    }
-
-    #[test]
-    fn payload_extraction_non_string_fallback() {
-        let h = thread::spawn(|| std::panic::panic_any(123u32));
-        let err = h.join().unwrap_err();
-        assert_eq!(
-            super::panic_payload_to_string(err),
-            "<non-string panic payload>"
-        );
-    }
 
     #[test]
     fn permits_are_returned_on_drop() {

--- a/tests/parallel_fetch.rs
+++ b/tests/parallel_fetch.rs
@@ -1,0 +1,65 @@
+//! End-to-end smoke test for the parallel fetch pipeline.
+//!
+//! `Coordinate`'s URL parser is opinionated about `forge/org/repo` shape and
+//! always emits `https://` or `ssh://`, so we cannot point real fixtures at
+//! `file://` URLs from a unit test. These tests therefore exercise the
+//! runtime/wiring with empty dependency graphs, asserting that the tokio
+//! runtime is built, the lock file is produced, and the proto output
+//! directory is created. The behavior of the parallel resolver itself is
+//! covered by `src/fetch/parallel.rs::tests`.
+
+use std::fs;
+
+use protofetch::{LockMode, Protofetch};
+use tempfile::TempDir;
+
+#[test]
+fn empty_descriptor_runs_through_parallel_pipeline() {
+    let project = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+
+    fs::write(
+        project.path().join("protofetch.toml"),
+        r#"name = "smoke_test"
+"#,
+    )
+    .unwrap();
+
+    let pf = Protofetch::builder()
+        .root(project.path().to_path_buf())
+        .cache_directory(cache.path().to_path_buf())
+        .jobs(8)
+        .copy_jobs(4)
+        .try_build()
+        .unwrap();
+
+    pf.fetch(LockMode::Update).unwrap();
+
+    let lock = fs::read_to_string(project.path().join("protofetch.lock")).unwrap();
+    assert!(lock.contains("version = 2"), "got lockfile: {}", lock);
+    assert!(project.path().join("proto_src").is_dir());
+}
+
+#[test]
+fn jobs_one_falls_back_to_sequential_behavior() {
+    let project = TempDir::new().unwrap();
+    let cache = TempDir::new().unwrap();
+
+    fs::write(
+        project.path().join("protofetch.toml"),
+        r#"name = "smoke_test"
+"#,
+    )
+    .unwrap();
+
+    let pf = Protofetch::builder()
+        .root(project.path().to_path_buf())
+        .cache_directory(cache.path().to_path_buf())
+        .jobs(1)
+        .copy_jobs(1)
+        .try_build()
+        .unwrap();
+
+    pf.fetch(LockMode::Update).unwrap();
+    pf.lock(LockMode::Locked).unwrap();
+}


### PR DESCRIPTION
## What

Run the three I/O stages of `protofetch fetch` concurrently using `std::thread::scope` instead of sequential `for` loops. No async runtime, no extra heavy dependency — just std primitives and a 25-line counting `Semaphore` (`Mutex<usize> + Condvar`).

- **Stage 1 — resolve:** new `fetch::parallel::parallel_resolve` runs a level-by-level BFS over the dep graph. Siblings within a level resolve concurrently under the network semaphore (default 16); the next level isn't scheduled until the current one drains, so per-name dedup happens in declaration order and matches the sequential resolver's "first wins + warn" semantics exactly.
- **Stage 2 — `fetch_sources`:** scoped-thread fan-out gated by the same network semaphore.
- **Stage 3 — `copy_proto_files`:** per-dep work runs on a separate disk semaphore (default `max(4, cpus/2)`) so network and disk concurrency are tunable independently.
- **Per-coordinate locking:** new `CoordinateLocks` is a `Mutex<HashMap<Coordinate, Arc<Mutex<()>>>>` — the outer mutex is held only briefly to look up or insert the per-coord `Arc<Mutex<()>>`, which then serializes operations against the same on-disk bare repo while letting different repos run in parallel. libgit2 is per-`Repository` thread-safe, but same-repo concurrent ref writes race.
- **Public API unchanged:** `Protofetch::fetch` / `Protofetch::lock` are still sync — they call sync handlers that use `thread::scope` internally. New CLI flags `--jobs` / `--copy-jobs` (and env vars `PROTOFETCH_JOBS` / `PROTOFETCH_COPY_JOBS`) for tuning. Static asserts in `src/api/mod.rs` and `src/git/cache.rs` lock in `Send + Sync + UnwindSafe + RefUnwindSafe` on the public types so semver auto-trait flow is guaranteed.

Send/Sync sweep required to share the cache across thread boundaries: `ModuleResolver` and `RepositoryCache` traits gain `Send + Sync` super-bounds, `LockFileModuleResolver` owns its `LockFile` (no more borrow lifetime), `Arc<T>` blanket-impls `ModuleResolver`. `git2::Config` is `!Send + !Sync` so it's no longer cached on `ProtofetchGitCache`; `fetch_options` opens a fresh `Config::open_default()` per call (cheap).

**Dependencies:** none added. Initially this work was prototyped on top of `tokio` (runtime + `sync::Semaphore` + `task::JoinSet` + `task::spawn_blocking`) and `dashmap`; per code-owner feedback, both have been removed in favor of `std::thread::scope` plus the small custom `Semaphore` since we never used any actually-async behavior.

## Why

CI runs of `protofetch fetch` on the cx-web-workspace `protofetch.toml` were spending most of their wall-clock waiting on TCP/TLS handshakes one repo at a time. With ~60 deps and per-fetch latency of 1–2s, sequential execution gives a wall-clock that's a sum, when most of those calls could overlap.

## Testing

### Unit tests

New tests in `src/fetch/parallel.rs`:
- `matches_sequential_diamond_graph` — parallel ≡ sequential on a transitive graph
- `first_wins_when_same_name_resolves_to_different_coords` — preserves the sequential dedup
- `transitive_conflicts_dedupe_in_declaration_order` — regression test that runs 30× and asserts declared-first parent always wins (this is the bug the determinism fix addresses)
- `coordinate_lock_serializes_same_repo` — asserts max in-flight = 1 when 3 deps share a coordinate

New tests in `src/git/coord_locks.rs` for lock identity + concurrent stress, in `src/sync.rs` for the new `Semaphore` (permit-on-drop and concurrency cap), and in `tests/parallel_fetch.rs` for an end-to-end smoke through the public API. **Final test count: 43 lib + 2 integration = 45 passing.** All previously existing tests pass unchanged.

### Real-workload benchmark

Subject: https://github.com/coralogix/cx-web-workspace/blob/master/libs/protos/protofetch.toml (59 declared deps → 61 in lock after transitive resolution).

5 cold-cache runs each, fresh cache directory per run, OLD = published `protofetch 0.1.15`, NEW = this branch with `--jobs 16 --copy-jobs 4`:

| Run | OLD 0.1.15 | NEW (parallel) | Speedup |
|---:|---:|---:|---:|
| 1 | 200.61s | 77.63s | 2.58× |
| 2 | 297.43s | 56.83s | 5.23× |
| 3 | 187.72s | 74.30s | 2.53× |
| 4 | 209.36s | 56.01s | 3.74× |
| 5 | 193.48s | 67.61s | 2.86× |

| | OLD | NEW |
|---|---:|---:|
| Mean   | 217.7s | **66.5s** |
| Median | 200.6s | **67.6s** |
| Min    | 187.7s | **56.0s** |
| Max    | 297.4s | **77.6s** |

**~3.3× faster on the mean.** Warm `fetch --locked` against a populated cache: 0.56s → 0.25s (~2.2×).

The 5×5 numbers above were captured on the original tokio prototype. After the std-thread refactor the same workload was re-run (cold, `--jobs 16`) and finished in **55.24s** — within the NEW range above — with the lockfile and the full `proto_src` tree byte-identical to the tokio-version reference (same MD5 / same aggregate SHA256, see below).

### Output regression check

Same `protofetch.toml`, fresh runs of OLD and NEW into separate output directories, then diffed:

| Metric | OLD | NEW |
|---|---:|---:|
| Lockfile md5 | `c58845ab…` | `c58845ab…` |
| Total size (KB) | 5608 | 5608 |
| Total bytes | 2,996,852 | 2,996,852 |
| File count | 972 | 972 |
| Directory count | 388 | 388 |
| Aggregate SHA256 (sorted name + per-file SHA256) | `7805856f…f2f6` | `7805856f…f2f6` |

`diff -qr` over the entire `proto_src/` tree returned zero differences. NEW produces bit-for-bit identical artifacts to 0.1.15. The std-thread refactor was verified to keep both fingerprints (`c58845ab…f2f6` lockfile, `7805856f…f2f6` aggregate) exactly identical.

## Out of scope (intentional)

- **Coalescing same-coord fetches** — separate optimization on top; the per-coord lock already keeps same-repo ops correct, coalescing reduces redundant cold-cache fetches further.
- **Async public API / gix migration** — explicitly post-0.2 in the original plan.
- **Indicatif progress bars** — log lines already convey ordering; can land separately.