### PR TITLE
Update release workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,5 +246,8 @@ jobs:
   release:
     if: github.repository == 'coralogix/protofetch' && startsWith(github.ref, 'refs/tags/')
     needs: [ package, test-npm-package ]
+    permissions:
+      id-token: write
+      contents: write
     uses: ./.github/workflows/release.yml
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ github ]
     if: github.repository == 'coralogix/protofetch'
-    permissions:
-      id-token: write
-      contents: read
+    env:
+      NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
     steps:
       - name: Checkout
@@ -35,6 +34,7 @@ jobs:
       - name: Publish npm package (cx-protofetch)
         run: |
           node .github/npm/prepare-package.js --package cx-protofetch
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ".npmrc"
           npm publish .github/npm/dist/cx-protofetch
 
   npm-coralogix-protofetch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Publish cargo package
         run: cargo publish --token ${{ env.CRATES_IO_TOKEN }}
@@ -24,52 +24,54 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ github ]
     if: github.repository == 'coralogix/protofetch'
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Publish npm package (cx-protofetch)
         run: |
           node .github/npm/prepare-package.js --package cx-protofetch
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ".npmrc"
           npm publish .github/npm/dist/cx-protofetch
 
   npm-coralogix-protofetch:
     runs-on: ubuntu-latest
     needs: [ github ]
     if: github.repository == 'coralogix/protofetch'
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Publish npm package (@coralogix/protofetch)
         run: |
           node .github/npm/prepare-package.js --package coralogix-protofetch
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ".npmrc"
           npm publish .github/npm/dist/coralogix-protofetch
 
   github:
     runs-on: ubuntu-latest
     if: github.repository == 'coralogix/protofetch'
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: package-*
           merge-multiple: true
 
       - name: Upload release artifacts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             protofetch_aarch64-unknown-linux-musl.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
       - name: Publish cargo package
         run: cargo publish --token ${{ env.CRATES_IO_TOKEN }}
 
-  # TODO: migrate to OIDC trusted publishing once npm-side access is available (see @coralogix/protofetch job below for reference)
   npm-cx-protofetch:
     runs-on: ubuntu-latest
     needs: [ github ]
     if: github.repository == 'coralogix/protofetch'
-    env:
-      NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -35,7 +35,6 @@ jobs:
       - name: Publish npm package (cx-protofetch)
         run: |
           node .github/npm/prepare-package.js --package cx-protofetch
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ".npmrc"
           npm publish .github/npm/dist/cx-protofetch
 
   npm-coralogix-protofetch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
       - name: Publish npm package (cx-protofetch)
         run: |
           node .github/npm/prepare-package.js --package cx-protofetch
@@ -48,6 +53,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
 
       - name: Publish npm package (@coralogix/protofetch)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Publish cargo package
         run: cargo publish --token ${{ env.CRATES_IO_TOKEN }}
 
+  # TODO: migrate to OIDC trusted publishing once npm-side access is available (see @coralogix/protofetch job below for reference)
   npm-cx-protofetch:
     runs-on: ubuntu-latest
     needs: [ github ]


### PR DESCRIPTION
## Summary
- Switch **both** npm packages (`cx-protofetch` and `@coralogix/protofetch`) from `NPM_TOKEN` secrets to OIDC trusted publishing
- Add per-job `id-token: write` permission scoped to the npm jobs only (cargo and github jobs do not request OIDC)
- Remove manual `.npmrc` token writes — npm CLI handles OIDC natively
- Add explicit `contents: write` permission to the `github` job (required by `action-gh-release` v3)
- Update actions: `actions/checkout` v4 → v6, `actions/download-artifact` v4 → v8, `softprops/action-gh-release` v1 → v3

## Prerequisites before merging

Both packages need a trusted publisher entry on npmjs.com pointing at this workflow. Workflow filename for both: `release.yml`, repo: `coralogix/protofetch`.

- [ ] Configure trusted publisher on npmjs.com for **`cx-protofetch`**
- [ ] Configure trusted publisher on npmjs.com for **`@coralogix/protofetch`**

## Notes
- No `--dry-run` step on PRs — `release.yml` is `workflow_call`-only and PR validation already happens via the `test-npm-package` matrix job in `ci.yml`. PR-level preview installs are covered separately by [#196](https://github.com/coralogix/protofetch/pull/196).
- `ci.yml` still has older action versions (checkout v3, download-artifact v4, etc.) — out of scope for this PR