### PR TITLE
Add per-PR preview releases for @coralogix/protofetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ on:
   push:
     branches:
       - master
-    tags: [ 'v*.*.*' ]
+    tags:
+      - 'v*.*.*'
+      - '!v*-pr.*'
 
 name: CI
 
@@ -242,6 +244,141 @@ jobs:
           else
             ./bin/protofetch --version
           fi
+
+  preview-release:
+    name: Preview Release
+    if: >-
+      github.repository == 'coralogix/protofetch' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: [ package, test-npm-package ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Compute preview version
+        id: version
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          VERSION="0.0.0-pr.${PR_NUMBER}.${SHORT_SHA}"
+          TAG="v${VERSION}"
+          {
+            echo "version=${VERSION}"
+            echo "tag=${TAG}"
+            echo "short_sha=${SHORT_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Download platform artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: package-*
+          merge-multiple: true
+
+      - name: Prepare @coralogix/protofetch with preview version
+        run: |
+          node .github/npm/prepare-package.js \
+            --package coralogix-protofetch \
+            --version ${{ steps.version.outputs.version }}
+
+      - name: Pack @coralogix/protofetch
+        id: pack
+        working-directory: .github/npm/dist/coralogix-protofetch
+        run: |
+          TARBALL=$(npm pack --json | jq -r '.[0].filename')
+          echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
+          echo "tarball_path=$(pwd)/${TARBALL}" >> "$GITHUB_OUTPUT"
+
+      - name: Create preview release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          SHORT_SHA: ${{ steps.version.outputs.short_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          TARBALL_PATH: ${{ steps.pack.outputs.tarball_path }}
+        run: |
+          gh release create "$TAG" \
+            --title "PR #$PR_NUMBER preview ($SHORT_SHA)" \
+            --notes "Preview build for PR #$PR_NUMBER (commit \`$SHORT_SHA\`). This release is automatically deleted when the PR is closed." \
+            --prerelease \
+            --target "$HEAD_SHA" \
+            artifacts/*.tar.gz \
+            "$TARBALL_PATH"
+
+      - name: Post or update PR comment
+        uses: actions/github-script@v7
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          SHORT_SHA: ${{ steps.version.outputs.short_sha }}
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        with:
+          script: |
+            const marker = '<!-- protofetch-preview-release -->';
+            const tag = process.env.TAG;
+            const shortSha = process.env.SHORT_SHA;
+            const tarball = process.env.TARBALL;
+            const installUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/${tag}/${tarball}`;
+            const releaseUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/tag/${tag}`;
+
+            const body = [
+              marker,
+              '## 📦 Preview release available',
+              '',
+              `A preview build of \`@coralogix/protofetch\` has been published for commit \`${shortSha}\`.`,
+              '',
+              '### Install',
+              '',
+              '```bash',
+              `npm install ${installUrl}`,
+              '```',
+              '',
+              `### Details`,
+              '',
+              `- **Release:** [${tag}](${releaseUrl})`,
+              `- **Tarball:** ${installUrl}`,
+              '',
+              `_This preview is automatically deleted when the PR is closed._`,
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              console.log(`✓ Updated existing comment #${existing.id}`);
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              console.log('✓ Created new preview comment');
+            }
 
   release:
     if: github.repository == 'coralogix/protofetch' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -278,12 +278,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 
       - name: Download platform artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: package-*
@@ -321,7 +321,7 @@ jobs:
             "$TARBALL_PATH"
 
       - name: Post or update PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TAG: ${{ steps.version.outputs.tag }}
           SHORT_SHA: ${{ steps.version.outputs.short_sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,9 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     needs: [ package, test-npm-package ]
     runs-on: ubuntu-latest
+    concurrency:
+      group: preview-release-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write
@@ -302,6 +305,23 @@ jobs:
           TARBALL=$(npm pack --json | jq -r '.[0].filename')
           echo "tarball=${TARBALL}" >> "$GITHUB_OUTPUT"
           echo "tarball_path=$(pwd)/${TARBALL}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete prior preview releases for this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Query tags by prefix server-side (no 200-cap pagination concern).
+          # Trailing dot disambiguates PR #1 from PR #12, etc.
+          gh api "repos/${GH_REPO}/git/matching-refs/tags/v0.0.0-pr.${PR_NUMBER}." \
+            --jq '.[].ref' 2>/dev/null \
+            | sed 's|^refs/tags/||' \
+            | while read -r tag; do
+                [ -z "$tag" ] && continue
+                echo "Deleting prior preview release ${tag}"
+                gh release delete "${tag}" --yes --cleanup-tag --repo "${GH_REPO}" || true
+              done
 
       - name: Create preview release
         env:

--- a/.github/workflows/preview-release-cleanup.yml
+++ b/.github/workflows/preview-release-cleanup.yml
@@ -1,0 +1,29 @@
+name: Preview Release Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    name: Delete preview release
+    if: github.repository == 'coralogix/protofetch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete preview releases for this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Match all preview release tags belonging to this PR (any commit SHA).
+          # gh release list returns tags newest-first; --cleanup-tag deletes the git tag too.
+          gh release list --limit 200 --json tagName --jq '.[].tagName' \
+            | grep -E "^v0\.0\.0-pr\.${PR_NUMBER}\." \
+            | while read -r tag; do
+                echo "Deleting preview release ${tag}"
+                gh release delete "${tag}" --yes --cleanup-tag || true
+              done

--- a/.github/workflows/preview-release-cleanup.yml
+++ b/.github/workflows/preview-release-cleanup.yml
@@ -19,11 +19,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # Match all preview release tags belonging to this PR (any commit SHA).
-          # gh release list returns tags newest-first; --cleanup-tag deletes the git tag too.
-          gh release list --limit 200 --json tagName --jq '.[].tagName' \
-            | grep -E "^v0\.0\.0-pr\.${PR_NUMBER}\." \
+          # Query tags by prefix server-side via the matching-refs API.
+          # Avoids the gh release list 200-cap and scales independently of repo size.
+          # Trailing dot disambiguates PR #1 from PR #12, etc.
+          gh api "repos/${GH_REPO}/git/matching-refs/tags/v0.0.0-pr.${PR_NUMBER}." \
+            --jq '.[].ref' 2>/dev/null \
+            | sed 's|^refs/tags/||' \
             | while read -r tag; do
+                [ -z "$tag" ] && continue
                 echo "Deleting preview release ${tag}"
-                gh release delete "${tag}" --yes --cleanup-tag || true
+                gh release delete "${tag}" --yes --cleanup-tag --repo "${GH_REPO}" || true
               done


### PR DESCRIPTION
## Summary

Adds a `preview-release` job that publishes a working preview of `@coralogix/protofetch` for every PR, mirroring the pattern used in [`frontops-dev/domino`](https://github.com/frontops-dev/domino).

**How it works:**
1. After the existing `package` matrix builds all platform binaries, a new job creates a GitHub prerelease tagged `v0.0.0-pr.<num>.<sha>`.
2. All five platform `protofetch_<target>.tar.gz` files are uploaded as release assets — the URL pattern matches what `getBinary.js` constructs at install time, so the existing install logic works **without any code changes**.
3. The wrapper package is prepared via `prepare-package.js --version 0.0.0-pr.<num>.<sha>`, packed with `npm pack`, and uploaded to the same release.
4. A sticky PR comment posts the `npm install <tarball-url>` command.

**One preview per PR:** A `delete-before-create` step + concurrency group (`preview-release-<pr-number>`, `cancel-in-progress: true`) keeps each PR at exactly one active preview at any time, even with rapid pushes.

**Cleanup:** A companion workflow (`preview-release-cleanup.yml`) listens for `pull_request: closed` and deletes the preview release + tag. Both create-time and close-time cleanup query tags by prefix via `gh api .../git/matching-refs/tags/v0.0.0-pr.<num>.` — server-side filtering, so cleanup scales independently of total repo release count (no `gh release list` 200-cap concern).

**Trigger gating:** The push trigger's `tags:` filter now excludes `-pr.` tags (`!v*-pr.*`) so creating the preview tag doesn't re-fire CI's real release pipeline.

## Tradeoffs / out of scope

- **No fork support** — the job is gated to same-repo PRs (`head.repo.full_name == github.repository`). Fork PRs from external contributors won't get a preview. If we need that later, we can switch to a `workflow_run`-based design like domino's.
- **Only `@coralogix/protofetch`**, not `cx-protofetch` (per request — `cx-protofetch` is deprecated).
- This PR doesn't touch the existing `release.yml` (OIDC migration) — that's tracked in [#195](https://github.com/coralogix/protofetch/pull/195) and is independent.
- **Comment-update race** under asymmetric matrix-runner timing is a known narrow edge case; deferred unless it bites in practice (see resolved discussion thread).

## Reviewer install command

Reviewers see a comment like:

```bash
npm install https://github.com/coralogix/protofetch/releases/download/v0.0.0-pr.123.abc1234/coralogix-protofetch-0.0.0-pr.123.abc1234.tgz
```

That `npm install` triggers the wrapper's `postinstall` → `getBinary.js` → fetches the platform binary from the same release. End-to-end, the preview install behaves exactly like a real release install.

## Verified end-to-end

Across 3 commits on this branch (`a5b049e` → `32f0136` → `266ddae`):

| Check | Result |
|---|---|
| One active preview tag at a time, not three | ✅ only `v0.0.0-pr.196.266ddae` present after 3 commits — `delete-before-create` working |
| Release contains wrapper tgz + 5 platform binaries with correct sizes | ✅ `coralogix-protofetch-0.0.0-pr.196.266ddae.tgz` (5.6 KB) + 5 platform tarballs (~16 MB total) |
| Single sticky PR comment, updated in place across runs (not duplicated) | ✅ created `11:48:04Z`, updated `12:21:45Z`, one comment total |
| Install URL resolves | ✅ `curl` → 302 → 200, `content-length: 5607` matches the asset size |
| `npm install <preview-url>` works in a clean directory | ✅ wrapper extracted, `postinstall` ran, platform binary downloaded |
| Installed binary executes | ✅ `node_modules/.bin/protofetch --version` → `protofetch 0.1.15` |

### Observed transient failure

The middle commit's run (`32f0136`) failed at `gh release create` with `HTTP 403: Resource not accessible by integration`. The workflow YAML at that commit was identical (same `permissions:` block) to the runs immediately before and after, both of which succeeded — almost certainly a transient GitHub token-issuance hiccup, not a code issue. Recovery was clean: the next commit's `delete-before-create` saw no leftover release for `32f0136` (because it was never created) and `a5b049e`'s release was cleaned up correctly. End state matched what we'd get if the failed run had never happened.

This is a useful real-world data point that the design is **retry-safe by construction** — `delete-before-create` is idempotent, so the next successful run self-heals from any partial-failure state.

## Cleanup-on-close test plan

Cleanup-on-close can only be verified once this PR is closed/merged, since it triggers on `pull_request: closed`. After merge:

- [ ] Confirm `v0.0.0-pr.196.*` tags are deleted (currently 1 active tag)
- [ ] Confirm the cleanup workflow run completed successfully