### PR TITLE
feat(build): omit dependencies if building as lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,23 @@ keywords = ["proto", "cli", "protobuf", "dependency-manager", "grpc"]
 categories = ["command-line-utilities"]
 exclude = [".github", ".gitignore"]
 
+[[bin]]
+name = "protofetch"
+required-features = ["build-binary"]
+
 [features]
+default = ["build-binary"]
+build-binary = ["dep:clap", "dep:env_logger"]
 vendored-openssl = ["git2/vendored-openssl"]
 vendored-libgit2 = ["git2/vendored-libgit2"]
 
 [dependencies]
 anyhow = "1.0.98"
-clap = { version = "4.5.36", features = ["derive"] }
+clap = { version = "4.5.36", features = ["derive"], optional = true }
 config = { version = "0.15.11", default-features = false, features = ["toml"] }
-env_logger = { version = "0.11.8", default-features = false, features = ["auto-color"] }
+env_logger = { version = "0.11.8", default-features = false, features = [
+	"auto-color",
+], optional = true }
 fs4 = "0.13.1"
 git2 = ">=0.18.0, <0.21.0"
 # Upgrading home to 0.5.11 will bring MSRV to 1.81.0


### PR DESCRIPTION
There is an unfortunate consequence of using protofetch as a build dependency (or as a library in general), which is pulling clap and env_logger with it.

This patch adds new build-binary feature flag (mandatory for building the protofetch binary) and makes binary-only dependencies optional, so that users can depend on protofetch with default-features off for a more lightweight build.

Note that build-binary is by default enabled, so this shouldn't be a breaking change unless someone explicitly used both `--no-default-features` and `--bin`.

### Testing
 - tried building this branch with/without default features and both as lib/bin
 - tried a dummy project that depended on this protofetch with default features off and checked that there's no clap in `cargo tree`'s output 

### Alternative
Alternatively, protofetch could be split into  separate bin/lib packages, but that would involve larger refactoring.