### PR TITLE
Fix OIDC by declaring workflow-level permissions in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
 
 name: Release
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## What happened

The `v0.1.16` release ([run 26224846122](https://github.com/coralogix/protofetch/actions/runs/26224846122)) failed at `npm publish`:

\`\`\`
npm error code ENEEDAUTH
npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
\`\`\`

Note that the failure happened **before** any registry call — npm never logged the usual \`Publishing to https://registry.npmjs.org/\` line, meaning it found no auth credentials of any kind (no token, no OIDC env vars).

## Root cause

The runtime \`GITHUB_TOKEN Permissions\` block in the failed job showed only:

\`\`\`
Contents: read
Metadata: read
\`\`\`

**No \`ID Token: write\`** — despite both the caller (\`ci.yml\`'s \`release\` job) granting it and the callee (\`release.yml\`'s npm jobs) declaring it.

Cause: when a reusable workflow (invoked via \`workflow_call\`) has **no workflow-level \`permissions:\` block**, GitHub Actions falls back to the repo's default token permissions and the per-job \`permissions:\` declarations inside the called workflow don't take effect. The OIDC env vars (\`ACTIONS_ID_TOKEN_REQUEST_URL\` / \`_TOKEN\`) were never injected, so npm CLI couldn't even attempt OIDC auth.

## Fix

Add workflow-level \`permissions:\` to \`release.yml\` to establish the baseline:

\`\`\`yaml
permissions:
  id-token: write
  contents: read
\`\`\`

Per-job overrides still work on top of this — e.g. the \`github\` job's \`permissions: contents: write\` continues to function as before.

## Verification

Cannot be tested without producing a real tag. Recommended path: cut a patch release (\`v0.1.17\`) once this merges and confirm the \`release / npm-coralogix-protofetch\` and \`release / npm-cx-protofetch\` jobs succeed. If they still fail with \`ENEEDAUTH\` after this change, the next thing to check is whether the trusted publisher entries on npmjs.com are correctly configured for both \`@coralogix/protofetch\` and \`cx-protofetch\` with workflow filename \`release.yml\`.

## Background

This is the third footgun encountered while wiring up OIDC for protofetch:
1. Caller job permissions must grant the union of all child jobs' needs ([#195](https://github.com/coralogix/protofetch/pull/195))
2. Node ≥ 22.14 / npm ≥ 11.5.1 required ([#195](https://github.com/coralogix/protofetch/pull/195))
3. Called workflow needs workflow-level permissions baseline (this PR)