### PR TITLE
chore: release v0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/coralogix/protofetch/compare/v0.1.16...v0.1.17) - 2026-05-22
+
+### Other
+
+- Update rust toolchain to 1.95.0 ([#200](https://github.com/coralogix/protofetch/pull/200))
+
 ## [0.1.16](https://github.com/coralogix/protofetch/compare/v0.1.15...v0.1.16) - 2026-05-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `protofetch`: 0.1.16 -> 0.1.17

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.17](https://github.com/coralogix/protofetch/compare/v0.1.16...v0.1.17) - 2026-05-22

### Other

- Update rust toolchain to 1.95.0 ([#200](https://github.com/coralogix/protofetch/pull/200))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).