### PR TITLE
debug: investigate OIDC trusted publishing failure (DO NOT MERGE)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,13 @@
 on:
   workflow_call:
+  # debug: direct trigger so release.yml fires on this branch without
+  # going through ci.yml. This makes the OIDC claim's workflow_ref equal
+  # to release.yml (instead of ci.yml under workflow_call), letting us
+  # verify the trusted-publisher entry on npmjs.com. Push-only so
+  # opening a PR doesn't fire ci.yml's preview-release job as a side effect.
+  push:
+    branches:
+      - debug/oidc-claims-inspection
 
 name: Release
 
@@ -13,7 +21,7 @@ env:
 jobs:
   cargo:
     runs-on: ubuntu-latest
-    if: github.repository == 'coralogix/protofetch'
+    if: false  # debug: skip crates.io publish during OIDC investigation
     env:
       CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
@@ -26,7 +34,7 @@ jobs:
 
   npm-cx-protofetch:
     runs-on: ubuntu-latest
-    needs: [ github ]
+    # needs: [ github ]  # debug: detached so the skipped github job doesn't block this one
     if: github.repository == 'coralogix/protofetch'
     permissions:
       id-token: write
@@ -41,14 +49,65 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Publish npm package (cx-protofetch)
+      - name: Workflow context
+        run: |
+          echo "event_name:   ${{ github.event_name }}"
+          echo "ref:          ${{ github.ref }}"
+          echo "ref_type:     ${{ github.ref_type }}"
+          echo "sha:          ${{ github.sha }}"
+          echo "workflow:     ${{ github.workflow }}"
+          echo "workflow_ref: ${{ github.workflow_ref }}"
+          echo "job:          ${{ github.job }}"
+          echo "run_id:       ${{ github.run_id }}"
+          echo "node:         $(node --version)"
+          echo "npm:          $(npm --version)"
+          echo "registry:     $(npm config get registry)"
+
+      - name: Inspect OIDC token claims
+        run: |
+          set -euo pipefail
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN set: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}"
+          if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+            ID_TOKEN=$(curl -sSL \
+              -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" \
+              | jq -r .value)
+            PAYLOAD=$(echo "$ID_TOKEN" | cut -d. -f2 \
+              | python3 -c "import sys,base64,json; r=sys.stdin.read().strip(); r+='='*(-len(r)%4); print(json.dumps(json.loads(base64.urlsafe_b64decode(r))))")
+            echo "Relevant claims (token itself NOT printed):"
+            echo "$PAYLOAD" | jq '{repository, repository_owner, workflow, workflow_ref, job_workflow_ref, ref, ref_type, environment, sub}'
+          else
+            echo "OIDC env vars are NOT set — id-token: write is not effective at runtime."
+          fi
+
+      - name: Publish npm package (cx-protofetch) [dry-run, verbose]
         run: |
           node .github/npm/prepare-package.js --package cx-protofetch
-          npm publish .github/npm/dist/cx-protofetch
+          npm publish --dry-run --loglevel=verbose .github/npm/dist/cx-protofetch
+
+      - name: Dump npm debug log
+        if: always()
+        run: |
+          ls -la /home/runner/.npm/_logs/ || true
+          for f in /home/runner/.npm/_logs/*-debug-0.log; do
+            [[ -f "$f" ]] && { echo "::group::$f"; cat "$f"; echo "::endgroup::"; }
+          done
+
+      - name: Highlight OIDC events in npm debug log
+        if: always()
+        run: |
+          for f in /home/runner/.npm/_logs/*-debug-0.log; do
+            if [[ -f "$f" ]]; then
+              echo "::group::OIDC-related lines in $f"
+              grep -iE "oidc|trusted.publish|id.token|token.exchange|/oidc/|ENEEDAUTH" "$f" || echo "(no OIDC matches)"
+              echo "::endgroup::"
+            fi
+          done
 
   npm-coralogix-protofetch:
     runs-on: ubuntu-latest
-    needs: [ github ]
+    # needs: [ github ]  # debug: detached so the skipped github job doesn't block this one
     if: github.repository == 'coralogix/protofetch'
     permissions:
       id-token: write
@@ -63,14 +122,65 @@ jobs:
         with:
           node-version: '24'
 
-      - name: Publish npm package (@coralogix/protofetch)
+      - name: Workflow context
+        run: |
+          echo "event_name:   ${{ github.event_name }}"
+          echo "ref:          ${{ github.ref }}"
+          echo "ref_type:     ${{ github.ref_type }}"
+          echo "sha:          ${{ github.sha }}"
+          echo "workflow:     ${{ github.workflow }}"
+          echo "workflow_ref: ${{ github.workflow_ref }}"
+          echo "job:          ${{ github.job }}"
+          echo "run_id:       ${{ github.run_id }}"
+          echo "node:         $(node --version)"
+          echo "npm:          $(npm --version)"
+          echo "registry:     $(npm config get registry)"
+
+      - name: Inspect OIDC token claims
+        run: |
+          set -euo pipefail
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${ACTIONS_ID_TOKEN_REQUEST_URL:+yes}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN set: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}"
+          if [[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]]; then
+            ID_TOKEN=$(curl -sSL \
+              -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" \
+              | jq -r .value)
+            PAYLOAD=$(echo "$ID_TOKEN" | cut -d. -f2 \
+              | python3 -c "import sys,base64,json; r=sys.stdin.read().strip(); r+='='*(-len(r)%4); print(json.dumps(json.loads(base64.urlsafe_b64decode(r))))")
+            echo "Relevant claims (token itself NOT printed):"
+            echo "$PAYLOAD" | jq '{repository, repository_owner, workflow, workflow_ref, job_workflow_ref, ref, ref_type, environment, sub}'
+          else
+            echo "OIDC env vars are NOT set — id-token: write is not effective at runtime."
+          fi
+
+      - name: Publish npm package (@coralogix/protofetch) [dry-run, verbose]
         run: |
           node .github/npm/prepare-package.js --package coralogix-protofetch
-          npm publish .github/npm/dist/coralogix-protofetch
+          npm publish --dry-run --loglevel=verbose .github/npm/dist/coralogix-protofetch
+
+      - name: Dump npm debug log
+        if: always()
+        run: |
+          ls -la /home/runner/.npm/_logs/ || true
+          for f in /home/runner/.npm/_logs/*-debug-0.log; do
+            [[ -f "$f" ]] && { echo "::group::$f"; cat "$f"; echo "::endgroup::"; }
+          done
+
+      - name: Highlight OIDC events in npm debug log
+        if: always()
+        run: |
+          for f in /home/runner/.npm/_logs/*-debug-0.log; do
+            if [[ -f "$f" ]]; then
+              echo "::group::OIDC-related lines in $f"
+              grep -iE "oidc|trusted.publish|id.token|token.exchange|/oidc/|ENEEDAUTH" "$f" || echo "(no OIDC matches)"
+              echo "::endgroup::"
+            fi
+          done
 
   github:
     runs-on: ubuntu-latest
-    if: github.repository == 'coralogix/protofetch'
+    if: false  # debug: skip GitHub release creation during OIDC investigation
     permissions:
       contents: write
 


### PR DESCRIPTION
## Purpose

Investigate why OIDC trusted publishing has been failing on `v0.1.16` and `v0.1.17` with `ENEEDAUTH`.

**Theory**: when a reusable workflow is invoked via `workflow_call`, npm validates the OIDC token against the **calling** workflow's filename (`ci.yml`), not the called workflow's filename (`release.yml`). Per the [npm docs](https://docs.npmjs.com/trusted-publishers):

> Some GitHub Actions workflows use `workflow_call` to invoke other workflows that run `npm publish`... When this happens, validation checks the calling workflow's name instead of the workflow that actually contains the publish command, which can cause configuration mismatches.

The Trusted Publisher entry on npmjs.com is currently configured with workflow filename `release.yml`. If the theory is correct, the entry should be `ci.yml` instead.

## What this PR does

**Debug/investigation branch — do not merge.** Modifies `release.yml` to:

1. Add a `push: branches: debug/oidc-claims-inspection` trigger so release.yml fires directly on this branch, bypassing the `workflow_call` indirection. With direct triggering, the OIDC `workflow_ref` claim equals `release.yml` — matching the existing npm config.
2. Skip the `cargo` and `github` jobs (`if: false`) so no crates.io publish or GitHub release happens.
3. Switch the npm publish steps to `npm publish --dry-run --loglevel=verbose` so the full auth flow runs (including the OIDC token exchange) but no tarball is uploaded.
4. Add diagnostic logging in each npm job:
   - Workflow context dump (event_name, ref, sha, npm version, registry URL).
   - OIDC token minting + decoded-claims inspection (`workflow_ref`, `job_workflow_ref`, `ref`, etc.) — the raw token is never printed.
   - Unconditional dump of npm's debug log (`if: always()`).
   - Grepped highlight of OIDC-related lines from the debug log.

## What to look for in the run output

In each npm job, the **"Inspect OIDC token claims"** step prints the OIDC token's decoded claims. The `workflow_ref` field is the critical signal:

- **`workflow_ref` ends in `release.yml`** AND the dry-run auth succeeds → theory confirmed. Production fails because `workflow_call` changes `workflow_ref` to `ci.yml`, which doesn't match the npm config of `release.yml`. **Fix**: update the npmjs.com Trusted Publisher entry from `release.yml` → `ci.yml` for both `@coralogix/protofetch` and `cx-protofetch`.
- **Auth fails even with direct release.yml triggering** → npm config has a different issue; the npm debug log dump + OIDC-events grep will reveal what npm CLI tried and what response it got.

## Safety

Three independent guard rails prevent any real publish:

- `cargo` job skipped — no crates.io publish.
- `github` job skipped — no GitHub release.
- `npm publish --dry-run` — auth flow runs end-to-end, but no tarball is uploaded.

## Cleanup

Close PR without merging when investigation is done. Delete the debug branch and the auto-created `v0.0.0-pr.N.SHA` preview release (preview-release-cleanup.yml handles the latter automatically on close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)