### PR TITLE
Add workflow-level id-token: write to ci.yml + npm-side filename fix needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,12 @@ jobs:
   update-release-draft:
     runs-on: ubuntu-latest
     if: github.repository == 'coralogix/protofetch' && github.ref == 'refs/heads/master'
+    # Workflow-level permissions narrow the default to `contents: read`, but
+    # release-drafter needs to create/update draft releases and read merged
+    # PRs for the release notes. Restore the scopes it needs here.
+    permissions:
+      contents: write
+      pull-requests: read
     steps:
       - uses: release-drafter/release-drafter@v7
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,17 @@ on:
 
 name: CI
 
+# OIDC trusted publishing for npm requires `id-token: write` at the workflow
+# level here (parent) AND at the workflow level of release.yml (child). Per
+# https://docs.npmjs.com/trusted-publishers : "The id-token: write permission
+# must also be given to both parent and child workflows."
+#
+# NPM-SIDE NOTE: ci.yml is the workflow filename that npm validates against
+# the OIDC token's `workflow_ref` claim, because release.yml is invoked via
+# `workflow_call`. Each npm package's trusted publisher on npmjs.com must
+# list "ci.yml" as the workflow filename. If you rename this file, update
+# every trusted publisher entry to match or releases will fail with
+# ENEEDAUTH at npm publish.
 permissions:
   id-token: write
   contents: read
@@ -407,6 +418,11 @@ jobs:
   release:
     if: github.repository == 'coralogix/protofetch' && startsWith(github.ref, 'refs/tags/')
     needs: [ package, test-npm-package ]
+    # When using `workflow_call`, the parent caller job's permissions are the
+    # ceiling for what the child workflow can request. We grant the union of
+    # everything the child needs:
+    # - id-token: write -> for npm OIDC trusted publishing (both npm jobs)
+    # - contents: write -> for the `github` job's release-asset upload
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 
 name: CI
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ on:
 
 name: Release
 
+# OIDC trusted publishing for npm requires `id-token: write` at the workflow
+# level here AND at the workflow level of the caller (ci.yml). Per
+# https://docs.npmjs.com/trusted-publishers : "The id-token: write permission
+# must also be given to both parent and child workflows."
+#
+# NPM-SIDE NOTE: because this workflow is invoked via `workflow_call`, npm's
+# trusted publisher entries on npmjs.com must list the CALLING workflow's
+# filename (ci.yml), NOT this file (release.yml). npm validates the OIDC
+# token's `workflow_ref` claim, which points at the entry-point workflow.
+# If you rename ci.yml or restructure the publish flow, update each
+# package's trusted publisher entry to match.
 permissions:
   id-token: write
   contents: read
@@ -28,6 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ github ]
     if: github.repository == 'coralogix/protofetch'
+    # Belt-and-suspenders: job-level id-token: write is technically redundant
+    # given the workflow-level grant above, but keeping it makes the OIDC
+    # requirement obvious at the job that actually uses it.
     permissions:
       id-token: write
       contents: read
@@ -36,6 +50,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Node >= 22.14 is required for npm >= 11.5.1, which is the minimum
+      # for OIDC trusted publishing auto-detection on npm CLI.
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -50,6 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ github ]
     if: github.repository == 'coralogix/protofetch'
+    # Belt-and-suspenders: job-level id-token: write is technically redundant
+    # given the workflow-level grant above, but keeping it makes the OIDC
+    # requirement obvious at the job that actually uses it.
     permissions:
       id-token: write
       contents: read
@@ -58,6 +77,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Node >= 22.14 is required for npm >= 11.5.1, which is the minimum
+      # for OIDC trusted publishing auto-detection on npm CLI.
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Why v0.1.17 still failed after PR #199

Two bugs, not one. PR #199 fixed the child workflow (`release.yml`). This PR addresses the parent (`ci.yml`), plus adds in-line documentation pointing future maintainers at the bigger issue: **the npm-side trusted publisher entries have the wrong workflow filename configured**.

## npm docs (verbatim)

From https://docs.npmjs.com/trusted-publishers :

> Some GitHub Actions workflows use `workflow_call` to invoke other workflows that run `npm publish`, or use `workflow_dispatch` for manual publishing. **When this happens, validation checks the calling workflow's name instead of the workflow that actually contains the publish command, which can cause configuration mismatches.** The `id-token: write` permission must also be given to **both parent and child workflows**.

## What this PR changes

### 1. Add workflow-level `id-token: write` to `ci.yml` (parent)

PR #199 added it to `release.yml` (child). The npm docs explicitly require it on **both**. Without the parent baseline, the runtime token may still not receive `id-token: write` even though the per-job declaration grants it.

### 2. Add explanatory comments to both workflow files

Future CI maintainers need to know:
- **Why** `id-token: write` is at the workflow level in both files (npm OIDC requirement)
- **What** to update on `npmjs.com` if these files are renamed
- **Which** workflow filename npm validates against (the entry-point — `ci.yml`, not `release.yml`)

If anyone restructures the publish flow or renames either workflow file, the comments point at exactly what must also be updated on npm side, or releases will fail with `ENEEDAUTH`.

## Required after this merges: fix npm-side trusted publisher filenames

**Manual action**, outside this PR, by whoever has npm admin on these packages:

- `https://www.npmjs.com/package/@coralogix/protofetch/access` → Trusted Publishers → change workflow filename from `release.yml` → `ci.yml`
- `https://www.npmjs.com/package/cx-protofetch/access` → Trusted Publishers → same change

After **both** this PR merges AND the npm-side filenames are corrected, the next release should succeed end-to-end.

## Background — the cascading miss

The original migration PR (#195) and my fix PR (#199) both told reviewers to configure `release.yml` as the npm-side workflow filename. That was wrong — should have been `ci.yml`. The relevant npm docs section explicitly calls out this quirk for `workflow_call` setups. Apologies for the cascading misdirection; the in-line comments are aimed at preventing the same mistake the next time someone touches this.