### PR TITLE
Gate real publishes on a full dry-run pass of every target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,19 @@ env:
 # Stage 1 — Dry-runs (run in parallel, none can be skipped):
 #     cargo-dry-run, npm-cx-protofetch-dry-run, npm-coralogix-protofetch-dry-run
 #
-# Stage 2 — Gate:
-#     dry-runs-passed (needs all dry-runs; just emits a "ready" signal)
+# Stage 2 — github (needs all dry-runs; acts as the convergence point):
+#     Creates the GitHub Release with platform binaries. If any dry-run
+#     failed, github is skipped and nothing downstream runs.
 #
-# Stage 3 — Real publishes (only after Stage 2):
-#     cargo, github, npm-cx-protofetch (needs github), npm-coralogix-protofetch
-#     (needs github)
+# Stage 3 — Real publishes (all need github):
+#     cargo, npm-cx-protofetch, npm-coralogix-protofetch
 #
-# Why: we previously had cases where `cargo publish` succeeded but `npm publish`
-# failed mid-release (e.g. v0.1.16/v0.1.17 OIDC misconfig), leaving us with a
-# crate on crates.io that didn't match the published npm packages. By gating
-# every real publish on a fresh dry-run of EVERY publish target, we catch
-# packaging/preparation errors before any side-effectful publish runs.
+# Why this ordering: we previously had cases where `cargo publish` succeeded
+# but `npm publish` failed mid-release (e.g. v0.1.16/v0.1.17), leaving us with
+# a crate on crates.io that didn't match the published npm packages. With
+# every real publish gated on (a) a clean dry-run of every target AND
+# (b) the github release existing, the failure modes that produce partial
+# publishes are tightly contained.
 #
 # Caveat: `npm publish --dry-run` does NOT contact the registry, so it won't
 # catch OIDC/auth misconfig. It catches packaging errors, malformed
@@ -112,37 +113,14 @@ jobs:
           node .github/npm/prepare-package.js --package coralogix-protofetch
           npm publish --dry-run .github/npm/dist/coralogix-protofetch
 
-  # -------- Stage 2: gate --------
-  # All real publishes depend (transitively or directly) on this job. If any
-  # dry-run fails, this job is skipped and no real publish runs. Adding a new
-  # publish target? Add it to Stage 1 AND to this gate's `needs:` list.
-
-  dry-runs-passed:
-    name: All dry-runs passed
-    needs: [ cargo-dry-run, npm-cx-protofetch-dry-run, npm-coralogix-protofetch-dry-run ]
-    runs-on: ubuntu-latest
-    if: github.repository == 'coralogix/protofetch'
-    steps:
-      - run: echo "✓ All publish dry-runs passed; proceeding to real publishes."
-
-  # -------- Stage 3: real publishes --------
-
-  cargo:
-    needs: [ dry-runs-passed ]
-    runs-on: ubuntu-latest
-    if: github.repository == 'coralogix/protofetch'
-    env:
-      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Publish cargo package
-        run: cargo publish --token ${{ env.CRATES_IO_TOKEN }}
+  # -------- Stage 2: github release (convergence point) --------
+  # Needs every dry-run. Every Stage 3 real publish needs this job, so a
+  # failed dry-run skips github, which in turn skips everything downstream.
+  # Adding a new publish target? Add its dry-run to Stage 1 AND to this
+  # job's `needs:` list.
 
   github:
-    needs: [ dry-runs-passed ]
+    needs: [ cargo-dry-run, npm-cx-protofetch-dry-run, npm-coralogix-protofetch-dry-run ]
     runs-on: ubuntu-latest
     if: github.repository == 'coralogix/protofetch'
     permissions:
@@ -167,6 +145,26 @@ jobs:
             protofetch_aarch64-apple-darwin.tar.gz
             protofetch_x86_64-apple-darwin.tar.gz
             protofetch_x86_64-pc-windows-msvc.tar.gz
+
+  # -------- Stage 3: real publishes (all gated on github) --------
+
+  cargo:
+    # Cargo doesn't technically need anything from the github release, but we
+    # gate on it anyway: if the github release fails, we don't want the crate
+    # on crates.io without a matching release tag/assets — that's the exact
+    # partial-publish state we're trying to prevent.
+    needs: [ github ]
+    runs-on: ubuntu-latest
+    if: github.repository == 'coralogix/protofetch'
+    env:
+      CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Publish cargo package
+        run: cargo publish --token ${{ env.CRATES_IO_TOKEN }}
 
   npm-cx-protofetch:
     # `github` must complete first: the published npm package's postinstall

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,7 @@ env:
 # Caveat: `npm publish --dry-run` does NOT contact the registry, so it won't
 # catch OIDC/auth misconfig. It catches packaging errors, malformed
 # package.json, and node-version issues. `cargo publish --dry-run` is offline
-# too. Once OIDC is correctly configured, the dry-run gate prevents the next
-# class of partial-publish failures.
+# too.
 # ============================================================================
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,17 @@ on:
 
 name: Release
 
+# OIDC trusted publishing for npm requires `id-token: write` at the workflow
+# level here AND at the workflow level of the caller (ci.yml). Per
+# https://docs.npmjs.com/trusted-publishers : "The id-token: write permission
+# must also be given to both parent and child workflows."
+#
+# NPM-SIDE NOTE: because this workflow is invoked via `workflow_call`, npm's
+# trusted publisher entries on npmjs.com must list the CALLING workflow's
+# filename (ci.yml), NOT this file (release.yml). npm validates the OIDC
+# token's `workflow_ref` claim, which points at the entry-point workflow.
+# If you rename ci.yml or restructure the publish flow, update each
+# package's trusted publisher entry to match.
 permissions:
   id-token: write
   contents: read
@@ -10,8 +21,115 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+# ============================================================================
+# Release pipeline structure
+# ----------------------------------------------------------------------------
+# Stage 1 — Dry-runs (run in parallel, none can be skipped):
+#     cargo-dry-run, npm-cx-protofetch-dry-run, npm-coralogix-protofetch-dry-run
+#
+# Stage 2 — Gate:
+#     dry-runs-passed (needs all dry-runs; just emits a "ready" signal)
+#
+# Stage 3 — Real publishes (only after Stage 2):
+#     cargo, github, npm-cx-protofetch (needs github), npm-coralogix-protofetch
+#     (needs github)
+#
+# Why: we previously had cases where `cargo publish` succeeded but `npm publish`
+# failed mid-release (e.g. v0.1.16/v0.1.17 OIDC misconfig), leaving us with a
+# crate on crates.io that didn't match the published npm packages. By gating
+# every real publish on a fresh dry-run of EVERY publish target, we catch
+# packaging/preparation errors before any side-effectful publish runs.
+#
+# Caveat: `npm publish --dry-run` does NOT contact the registry, so it won't
+# catch OIDC/auth misconfig. It catches packaging errors, malformed
+# package.json, and node-version issues. `cargo publish --dry-run` is offline
+# too. Once OIDC is correctly configured, the dry-run gate prevents the next
+# class of partial-publish failures.
+# ============================================================================
+
 jobs:
+  # -------- Stage 1: dry-runs --------
+
+  cargo-dry-run:
+    name: cargo (dry-run)
+    runs-on: ubuntu-latest
+    if: github.repository == 'coralogix/protofetch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Cache rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo publish --dry-run
+        run: cargo publish --dry-run
+
+  npm-cx-protofetch-dry-run:
+    name: npm-cx-protofetch (dry-run)
+    runs-on: ubuntu-latest
+    if: github.repository == 'coralogix/protofetch'
+    # id-token: write is included so that `npm publish --dry-run` runs under
+    # the same identity as the real publish. Even though dry-run doesn't
+    # contact the registry, keeping the env consistent avoids "works in
+    # dry-run, fails in real" surprises.
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Dry-run publish (cx-protofetch)
+        run: |
+          node .github/npm/prepare-package.js --package cx-protofetch
+          npm publish --dry-run .github/npm/dist/cx-protofetch
+
+  npm-coralogix-protofetch-dry-run:
+    name: npm-coralogix-protofetch (dry-run)
+    runs-on: ubuntu-latest
+    if: github.repository == 'coralogix/protofetch'
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Dry-run publish (@coralogix/protofetch)
+        run: |
+          node .github/npm/prepare-package.js --package coralogix-protofetch
+          npm publish --dry-run .github/npm/dist/coralogix-protofetch
+
+  # -------- Stage 2: gate --------
+  # All real publishes depend (transitively or directly) on this job. If any
+  # dry-run fails, this job is skipped and no real publish runs. Adding a new
+  # publish target? Add it to Stage 1 AND to this gate's `needs:` list.
+
+  dry-runs-passed:
+    name: All dry-runs passed
+    needs: [ cargo-dry-run, npm-cx-protofetch-dry-run, npm-coralogix-protofetch-dry-run ]
+    runs-on: ubuntu-latest
+    if: github.repository == 'coralogix/protofetch'
+    steps:
+      - run: echo "✓ All publish dry-runs passed; proceeding to real publishes."
+
+  # -------- Stage 3: real publishes --------
+
   cargo:
+    needs: [ dry-runs-passed ]
     runs-on: ubuntu-latest
     if: github.repository == 'coralogix/protofetch'
     env:
@@ -24,51 +142,8 @@ jobs:
       - name: Publish cargo package
         run: cargo publish --token ${{ env.CRATES_IO_TOKEN }}
 
-  npm-cx-protofetch:
-    runs-on: ubuntu-latest
-    needs: [ github ]
-    if: github.repository == 'coralogix/protofetch'
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Publish npm package (cx-protofetch)
-        run: |
-          node .github/npm/prepare-package.js --package cx-protofetch
-          npm publish .github/npm/dist/cx-protofetch
-
-  npm-coralogix-protofetch:
-    runs-on: ubuntu-latest
-    needs: [ github ]
-    if: github.repository == 'coralogix/protofetch'
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Publish npm package (@coralogix/protofetch)
-        run: |
-          node .github/npm/prepare-package.js --package coralogix-protofetch
-          npm publish .github/npm/dist/coralogix-protofetch
-
   github:
+    needs: [ dry-runs-passed ]
     runs-on: ubuntu-latest
     if: github.repository == 'coralogix/protofetch'
     permissions:
@@ -93,3 +168,50 @@ jobs:
             protofetch_aarch64-apple-darwin.tar.gz
             protofetch_x86_64-apple-darwin.tar.gz
             protofetch_x86_64-pc-windows-msvc.tar.gz
+
+  npm-cx-protofetch:
+    # `github` must complete first: the published npm package's postinstall
+    # script (getBinary.js) fetches the platform binary from the github
+    # release URL, so the release must exist before users install from npm.
+    needs: [ github ]
+    runs-on: ubuntu-latest
+    if: github.repository == 'coralogix/protofetch'
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Publish npm package (cx-protofetch)
+        run: |
+          node .github/npm/prepare-package.js --package cx-protofetch
+          npm publish .github/npm/dist/cx-protofetch
+
+  npm-coralogix-protofetch:
+    needs: [ github ]
+    runs-on: ubuntu-latest
+    if: github.repository == 'coralogix/protofetch'
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Publish npm package (@coralogix/protofetch)
+        run: |
+          node .github/npm/prepare-package.js --package coralogix-protofetch
+          npm publish .github/npm/dist/coralogix-protofetch


### PR DESCRIPTION
## Why

v0.1.16 and v0.1.17 left an inconsistent state: the cargo crate published successfully to crates.io but the npm packages failed mid-release. We want releases to be all-or-nothing — if any target can't publish, none of them should.

## What

Restructures `release.yml` into three stages:

**Stage 1 — parallel dry-runs:**
- \`cargo-dry-run\` → \`cargo publish --dry-run\`
- \`npm-cx-protofetch-dry-run\` → \`npm publish --dry-run\` on cx-protofetch
- \`npm-coralogix-protofetch-dry-run\` → \`npm publish --dry-run\` on @coralogix/protofetch

**Stage 2 — gate:**
- \`dry-runs-passed\` → needs all three Stage 1 jobs; emits a "ready" signal

**Stage 3 — real publishes (only if Stage 2 succeeded):**
- \`cargo\` (needs dry-runs-passed)
- \`github\` (needs dry-runs-passed) — creates the GitHub Release with platform assets
- \`npm-cx-protofetch\` (needs github)
- \`npm-coralogix-protofetch\` (needs github)

```
                       ┌─ cargo-dry-run ──┐
                       │                  │
release.yml triggers ──┼─ npm-cx-dry-run ─┼─→ dry-runs-passed ──┬─→ cargo
                       │                  │                     ├─→ github ─┬─→ npm-cx-protofetch
                       └─ npm-cor-dry-run ┘                     │           └─→ npm-coralogix-protofetch
```

## Honest caveat

\`npm publish --dry-run\` and \`cargo publish --dry-run\` are both **fully offline** — neither contacts its registry, so neither will catch OIDC/auth misconfig (the exact bug that caused v0.1.16/v0.1.17). What they DO catch:

- Malformed \`package.json\` / \`Cargo.toml\`
- Packaging errors (missing files, invalid version)
- Node-version mismatches (npm too old for OIDC, etc.)
- Crate verification failures (cargo compiles in dry-run)

Once OIDC is correctly wired (PR [#205](https://github.com/coralogix/protofetch/pull/205) + the npm-side trusted publisher filename fix), auth-related failures should be rare. The dry-run gate then protects against the next most common class — packaging/preparation issues that only surface at publish time.

## Naming and branch protection

The Stage 3 job names are unchanged (\`cargo\`, \`github\`, \`npm-cx-protofetch\`, \`npm-coralogix-protofetch\`). The new dry-run jobs are added alongside. If you have branch protection rules referencing the existing names, they still work.

## Adding a new publish target later

Two changes:
1. Add the new dry-run job to Stage 1
2. Add it to \`dry-runs-passed\`'s \`needs:\` list
3. Add the real publish job to Stage 3 with \`needs: [dry-runs-passed]\` (or transitively, e.g. via \`github\`)

The inline comments in \`release.yml\` walk through this.

## Verification

Tag-triggered workflow, so true end-to-end test requires cutting a release. Recommended path: merge PR #205 first (OIDC fix), fix the npm-side trusted publisher filenames, merge this PR, then cut a small patch release to verify both the OIDC fix AND the dry-run gating work together.