### PR TITLE
chore(ci): update remaining GitHub actions using Node.js 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,9 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v22
 
       - name: Cache nix dependencies
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
 
       - name: Build
         run: nix flake check
@@ -175,7 +177,7 @@ jobs:
           ${{ matrix.target.tar }} -czvf protofetch_${{ matrix.target.rust }}.tar.gz bin/protofetch${{ matrix.target.ext }}
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package-${{ matrix.target.rust }}
           path: protofetch_${{ matrix.target.rust }}.tar.gz


### PR DESCRIPTION
DeterminateSystems/magic-nix-cache-action was just released, and actions/upload-artifact was missed in the [previous PR](https://github.com/coralogix/protofetch/pull/202).