### PR TITLE
chore: replace config crate with toml + explicit env reading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,18 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "config"
-version = "0.15.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f316c6237b2d38be61949ecd15268a4c6ca32570079394a2444d9ce2c72a72d8"
-dependencies = [
- "pathdiff",
- "serde_core",
- "toml 1.1.2+spec-1.1.0",
- "winnow 1.0.3",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,12 +838,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,7 +947,6 @@ version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",
- "config",
  "env_logger",
  "fs4",
  "git2",
@@ -978,7 +959,7 @@ dependencies = [
  "ssh-key",
  "tempfile",
  "thiserror",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -1335,23 +1316,10 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "serde_core",
- "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
- "toml_parser",
- "winnow 1.0.3",
 ]
 
 [[package]]
@@ -1359,15 +1327,6 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -1598,9 +1557,6 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ vendored-libgit2 = ["git2/vendored-libgit2"]
 [dependencies]
 anyhow = "1.0.98"
 clap = { version = "4.5.36", features = ["derive"], optional = true }
-config = { version = "0.15.11", default-features = false, features = ["toml"] }
 env_logger = { version = "0.11.8", default-features = false, features = [
 	"auto-color",
 ], optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
-use anyhow::bail;
-use config::{Config, ConfigError, Environment, File, FileFormat};
+use anyhow::{bail, Context};
 use log::{debug, trace};
 use serde::Deserialize;
 
@@ -62,40 +61,63 @@ impl RawConfig {
         config_dir: Option<PathBuf>,
         config_override: Option<toml::Table>,
         env_override: Option<HashMap<String, String>>,
-    ) -> Result<Self, ConfigError> {
-        let mut builder = Config::builder();
-
-        if let Some(mut path) = config_dir {
+    ) -> anyhow::Result<Self> {
+        // Base config: override table (tests) takes priority; otherwise read
+        // the optional config.toml file; fall back to defaults.
+        let mut config: RawConfig = if let Some(table) = config_override {
+            table.try_into().context("invalid config override")?
+        } else if let Some(mut path) = config_dir {
             path.push("config.toml");
             debug!("Loading configuration from {}", path.display());
-            builder = builder.add_source(File::from(path).required(false));
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => toml::from_str(&contents)
+                    .with_context(|| format!("invalid config file at {}", path.display()))?,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => RawConfig::default(),
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!("could not read config file at {}", path.display())
+                    })
+                }
+            }
+        } else {
+            RawConfig::default()
+        };
+
+        // Overlay env vars; they win over the file.  The function abstracts
+        // the source so tests inject a HashMap and prod reads std::env.
+        fn get<T>(
+            key: &str,
+            env_override: &Option<HashMap<String, String>>,
+        ) -> anyhow::Result<Option<T>>
+        where
+            T: FromStr,
+            T::Err: std::error::Error + Send + Sync + 'static,
+        {
+            let raw = match env_override {
+                Some(map) => map.get(key).cloned(),
+                None => std::env::var(key).ok(),
+            };
+            raw.map(|v| {
+                v.parse()
+                    .with_context(|| format!("invalid value for {key}"))
+            })
+            .transpose()
         }
 
-        if let Some(config_override) = config_override {
-            builder = builder.add_source(File::from_str(
-                &config_override.to_string(),
-                FileFormat::Toml,
-            ));
+        if let Some(dir) = get::<PathBuf>("PROTOFETCH_CACHE_DIR", &env_override)? {
+            config.cache.dir = Some(dir);
+        }
+        if let Some(protocol) = get::<Protocol>("PROTOFETCH_GIT_PROTOCOL", &env_override)? {
+            config.git.protocol = Some(protocol);
+        }
+        if let Some(jobs) = get::<usize>("PROTOFETCH_JOBS", &env_override)? {
+            config.jobs = Some(jobs);
+        }
+        if let Some(copy_jobs) = get::<usize>("PROTOFETCH_COPY_JOBS", &env_override)? {
+            config.copy_jobs = Some(copy_jobs);
         }
 
-        // First pass: nested keys via `_` separator (maps PROTOFETCH_CACHE_DIR
-        // → cache.dir, PROTOFETCH_GIT_PROTOCOL → git.protocol, etc.).
-        // Second pass: flat keys with no separator (maps PROTOFETCH_JOBS →
-        // jobs, PROTOFETCH_COPY_JOBS → copy_jobs).  Sources added later win,
-        // so the flat-key pass takes precedence for the top-level fields.
-        builder
-            .add_source(
-                Environment::with_prefix("PROTOFETCH")
-                    .separator("_")
-                    .source(env_override.clone()),
-            )
-            .add_source(
-                Environment::with_prefix("PROTOFETCH")
-                    .prefix_separator("_")
-                    .source(env_override),
-            )
-            .build()?
-            .try_deserialize()
+        Ok(config)
     }
 }
 
@@ -158,6 +180,8 @@ mod tests {
         let env = HashMap::from([
             ("PROTOFETCH_CACHE_DIR".to_owned(), "/cache".to_owned()),
             ("PROTOFETCH_GIT_PROTOCOL".to_owned(), "ssh".to_owned()),
+            ("PROTOFETCH_JOBS".to_owned(), "16".to_owned()),
+            ("PROTOFETCH_COPY_JOBS".to_owned(), "4".to_owned()),
         ]);
         let config = RawConfig::load(None, Some(Default::default()), Some(env)).unwrap();
         assert_eq!(
@@ -169,21 +193,10 @@ mod tests {
                 git: GitConfig {
                     protocol: Some(Protocol::Ssh)
                 },
-                jobs: None,
-                copy_jobs: None,
+                jobs: Some(16),
+                copy_jobs: Some(4),
             }
         )
-    }
-
-    #[test]
-    fn load_environment_parallelism() {
-        let env = HashMap::from([
-            ("PROTOFETCH_JOBS".to_owned(), "16".to_owned()),
-            ("PROTOFETCH_COPY_JOBS".to_owned(), "4".to_owned()),
-        ]);
-        let config = RawConfig::load(None, Some(Default::default()), Some(env)).unwrap();
-        assert_eq!(config.jobs, Some(16));
-        assert_eq!(config.copy_jobs, Some(4));
     }
 
     #[test]


### PR DESCRIPTION
`config` crate is not a perfect fit for our use-case because of the way it handles separators in the environment variable names. We had to have two "env sources", one with `_` as a separator and one without a separator, but no separator actually means `.` so we were parsing some undocumented environment variables.
It feels easier to just use the `toml` crate directly and apply the environment variable overrides manually, which also makes the dependency tree a bit leaner.