### PR TITLE
chore: release v0.1.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,7 +981,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `protofetch`: 0.1.17 -> 0.1.18

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).