### PR TITLE
chore: release v0.1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18](https://github.com/coralogix/protofetch/compare/v0.1.17...v0.1.18) - 2026-06-05
+
+### Fixed
+
+- merge allow/deny policies across dependencies ([#210](https://github.com/coralogix/protofetch/pull/210))
+- scope worktrees per original repo paths ([#207](https://github.com/coralogix/protofetch/pull/207))
+
+### Other
+
+- add e2e tests ([#209](https://github.com/coralogix/protofetch/pull/209))
+- replace config crate with toml + explicit env reading ([#211](https://github.com/coralogix/protofetch/pull/211))
+- *(ci)* update remaining GitHub actions using Node.js 20 ([#208](https://github.com/coralogix/protofetch/pull/208))
+- Gate real publishes on a full dry-run pass of every target ([#206](https://github.com/coralogix/protofetch/pull/206))
+- Add workflow-level id-token: write to ci.yml + npm-side filename fix needed ([#205](https://github.com/coralogix/protofetch/pull/205))
+- update toml and other dependencies ([#201](https://github.com/coralogix/protofetch/pull/201))
+
 ## [0.1.17](https://github.com/coralogix/protofetch/compare/v0.1.16...v0.1.17) - 2026-05-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,7 +981,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `protofetch`: 0.1.17 -> 0.1.18

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.18](https://github.com/coralogix/protofetch/compare/v0.1.17...v0.1.18) - 2026-06-05

### Fixed

- merge allow/deny policies across dependencies ([#210](https://github.com/coralogix/protofetch/pull/210))
- scope worktrees per original repo paths ([#207](https://github.com/coralogix/protofetch/pull/207))

### Other

- add e2e tests ([#209](https://github.com/coralogix/protofetch/pull/209))
- replace config crate with toml + explicit env reading ([#211](https://github.com/coralogix/protofetch/pull/211))
- *(ci)* update remaining GitHub actions using Node.js 20 ([#208](https://github.com/coralogix/protofetch/pull/208))
- Gate real publishes on a full dry-run pass of every target ([#206](https://github.com/coralogix/protofetch/pull/206))
- Add workflow-level id-token: write to ci.yml + npm-side filename fix needed ([#205](https://github.com/coralogix/protofetch/pull/205))
- update toml and other dependencies ([#201](https://github.com/coralogix/protofetch/pull/201))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).