### PR TITLE
Add dependency root support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This can be changed, but it is heavily discouraged.
 | revision       | String   | Optional  | A revision to checkout, this can either be a tagged version or a commit hash       | `v0.2`                                                  |
 | branch         | Boolean  | Optional  | A branch to checkout, fetches last commit                                          | `feature/v2`                                            |
 | protocol       | String   | Optional  | A protocol to use: [ssh, https]                                                    | `ssh`                                                   |
+| root           | String   | Optional  | Repository subdirectory used as the root for descriptor loading, policies, and content roots | `"apis/users"`                                 |
 | allow_policies | [String] | Optional  | Allow policy rules (`*` at the beginning or end matches arbitrary directory depth) | `"/prefix/*"`, `"*/subpath/*"`, `"/path/to/file.proto"` |
 | deny_policies  | [String] | Optional  | Deny policy rules (`*` at the beginning or end matches arbitrary directory depth)  | `"/prefix/*"`, `"*/subpath/*"`, `"/path/to/file.proto"` |
 | prune          | bool     | Optional  | Whether to prune unneeded transitive proto files                                   | `true` / `false`                                        |
@@ -97,6 +98,7 @@ This can be changed, but it is heavily discouraged.
 | content_roots  | [String] | Optional  | Which subdirectories to import from                                                | `["/myservice", "/com/org/client"]`                     |
 
 The patterns in `allow_policies` and `deny_policies` are matched against the paths relative to the nearest path in `content_roots`.
+If `root` is set, dependency files, the dependency's own `protofetch.toml`, `content_roots`, and policies are all resolved relative to that root.
 
 ### Protofetch dependency toml example
 
@@ -123,6 +125,7 @@ transitive = true
 [scoped-down-dep4]
 url = "github.com/org/dep4"
 revision = "v1.1"
+root = "/apis"
 content_roots = ["/scope/path"]
 allow_policies = ["prefix/subpath/scoped_path/*"]
 ```

--- a/src/cache/git.rs
+++ b/src/cache/git.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::{
     git::cache::ProtofetchGitCache,
-    model::protofetch::{Coordinate, RevisionSpecification},
+    model::protofetch::{Coordinate, DependencyRoot, RevisionSpecification},
 };
 
 use super::RepositoryCache;
@@ -23,10 +23,11 @@ impl RepositoryCache for ProtofetchGitCache {
         &self,
         coordinate: &Coordinate,
         commit_hash: &str,
+        roots: &[DependencyRoot],
     ) -> anyhow::Result<PathBuf> {
         let path = self
             .repository(coordinate)?
-            .create_worktree(coordinate, commit_hash)?;
+            .create_worktree(coordinate, commit_hash, roots)?;
         Ok(path)
     }
 }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -2,7 +2,7 @@ mod git;
 
 use std::{path::PathBuf, sync::Arc};
 
-use crate::model::protofetch::{Coordinate, RevisionSpecification};
+use crate::model::protofetch::{Coordinate, DependencyRoot, RevisionSpecification};
 
 pub trait RepositoryCache: Send + Sync {
     fn fetch(
@@ -16,6 +16,7 @@ pub trait RepositoryCache: Send + Sync {
         &self,
         coordinate: &Coordinate,
         commit_hash: &str,
+        roots: &[DependencyRoot],
     ) -> anyhow::Result<PathBuf>;
 }
 
@@ -36,7 +37,8 @@ where
         &self,
         coordinate: &Coordinate,
         commit_hash: &str,
+        roots: &[DependencyRoot],
     ) -> anyhow::Result<PathBuf> {
-        T::create_worktree(self, coordinate, commit_hash)
+        T::create_worktree(self, coordinate, commit_hash, roots)
     }
 }

--- a/src/fetch/mod.rs
+++ b/src/fetch/mod.rs
@@ -116,6 +116,7 @@ pub(crate) mod tests {
                                 &dependency.specification,
                                 None,
                                 &dependency.name,
+                                dependency.rules.root.as_ref(),
                             )
                             .map_err(FetchError::Resolver)?;
 
@@ -220,6 +221,7 @@ pub(crate) mod tests {
             specification: &RevisionSpecification,
             _: Option<&str>,
             _: &ModuleName,
+            _: Option<&crate::model::protofetch::DependencyRoot>,
         ) -> anyhow::Result<CommitAndDescriptor> {
             Ok(self
                 .entries

--- a/src/fetch/parallel.rs
+++ b/src/fetch/parallel.rs
@@ -128,7 +128,13 @@ where
                         let _g = coord_lock.lock().expect("coord lock poisoned");
                         info!("Resolving {}", dep.coordinate);
                         let result = resolver
-                            .resolve(&dep.coordinate, &dep.specification, None, &dep.name)
+                            .resolve(
+                                &dep.coordinate,
+                                &dep.specification,
+                                None,
+                                &dep.name,
+                                dep.rules.root.as_ref(),
+                            )
                             .map_err(FetchError::Resolver)?;
                         Ok((idx, dep, result))
                     },
@@ -237,6 +243,7 @@ mod tests {
             specification: &RevisionSpecification,
             _: Option<&str>,
             _: &ModuleName,
+            _: Option<&crate::model::protofetch::DependencyRoot>,
         ) -> anyhow::Result<CommitAndDescriptor> {
             let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
             self.max_in_flight.fetch_max(now, Ordering::SeqCst);

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -1,7 +1,10 @@
-use std::{path::PathBuf, str::Utf8Error};
+use std::{
+    path::{Path, PathBuf},
+    str::Utf8Error,
+};
 
 use crate::model::protofetch::{
-    Coordinate, Descriptor, ModuleName, Revision, RevisionSpecification,
+    Coordinate, DependencyRoot, Descriptor, ModuleName, Revision, RevisionSpecification,
 };
 use git2::{Oid, Repository, ResetType, WorktreeAddOptions};
 use log::{debug, warn};
@@ -108,10 +111,15 @@ impl ProtoGitRepository<'_> {
         &self,
         dep_name: &ModuleName,
         commit_hash: &str,
+        root: Option<&DependencyRoot>,
     ) -> Result<Descriptor, ProtoRepoError> {
-        let result = self
-            .git_repo
-            .revparse_single(&format!("{commit_hash}:protofetch.toml"));
+        let descriptor_path = root
+            .map(|root| root.value.join("protofetch.toml"))
+            .unwrap_or_else(|| PathBuf::from("protofetch.toml"));
+        let result = self.git_repo.revparse_single(&format!(
+            "{commit_hash}:{}",
+            git_object_path(&descriptor_path)
+        ));
 
         match result {
             Err(e) if e.code() == git2::ErrorCode::NotFound => {
@@ -184,7 +192,9 @@ impl ProtoGitRepository<'_> {
         &self,
         coordinate: &Coordinate,
         commit_hash: &str,
+        _roots: &[DependencyRoot],
     ) -> Result<PathBuf, ProtoRepoError> {
+        // TODO: Use dependency roots to configure a sparse-checkout limited to those root paths.
         let mut base_path = self.cache.worktrees_path();
         base_path.push(coordinate.to_path());
 
@@ -265,5 +275,24 @@ impl ProtoGitRepository<'_> {
     // Check if `a` is an ancestor of `b`
     fn is_ancestor(&self, a: Oid, b: Oid) -> Result<bool, ProtoRepoError> {
         Ok(self.git_repo.merge_base(a, b)? == a)
+    }
+}
+
+fn git_object_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::git_object_path;
+
+    #[test]
+    fn git_object_path_uses_forward_slashes() {
+        assert_eq!(
+            git_object_path(&PathBuf::from(r"service\protofetch.toml")),
+            "service/protofetch.toml"
+        );
     }
 }

--- a/src/model/protofetch/mod.rs
+++ b/src/model/protofetch/mod.rs
@@ -280,11 +280,25 @@ impl Display for RevisionSpecification {
 
 #[derive(Default, Clone, Debug, Ord, PartialOrd, PartialEq, Eq, Hash)]
 pub struct Rules {
+    pub root: Option<DependencyRoot>,
     pub prune: bool,
     pub transitive: bool,
     pub content_roots: BTreeSet<ContentRoot>,
     pub allow_policies: AllowPolicies,
     pub deny_policies: DenyPolicies,
+}
+
+/// A dependency root path for a repository.
+#[derive(Ord, PartialOrd, PartialEq, Eq, Hash, Debug, Clone)]
+pub struct DependencyRoot {
+    pub value: PathBuf,
+}
+
+impl DependencyRoot {
+    pub fn from_string(s: &str) -> DependencyRoot {
+        let path = PathBuf::from(s.strip_prefix('/').unwrap_or(s));
+        DependencyRoot { value: path }
+    }
 }
 
 /// A content root path for a repository.
@@ -295,8 +309,7 @@ pub struct ContentRoot {
 
 impl ContentRoot {
     pub fn from_string(s: &str) -> ContentRoot {
-        let path = PathBuf::from(s);
-        let path = path.strip_prefix("/").unwrap_or(&path).to_path_buf();
+        let path = PathBuf::from(s.strip_prefix('/').unwrap_or(s));
         ContentRoot { value: path }
     }
 }
@@ -654,6 +667,12 @@ impl Descriptor {
             if let Some(branch) = d.specification.branch {
                 dependency.insert("branch".to_owned(), Value::String(branch));
             }
+            if let Some(root) = d.rules.root {
+                dependency.insert(
+                    "root".to_owned(),
+                    Value::String(root.value.to_string_lossy().to_string()),
+                );
+            }
             description.insert(d.name.to_string(), Value::Table(dependency));
         }
         Value::Table(description)
@@ -692,6 +711,12 @@ fn parse_dependency(name: String, value: &toml::Value) -> Result<Dependency, Par
         .map_or(Ok(None), |v| v.map(Some))?
         .unwrap_or(false);
 
+    let root = value
+        .get("root")
+        .map(|v| v.clone().try_into::<String>())
+        .map_or(Ok(None), |v| v.map(Some))?
+        .map(|str| DependencyRoot::from_string(&str));
+
     let content_roots = value
         .get("content_roots")
         .map(|v| v.clone().try_into::<Vec<String>>())
@@ -711,6 +736,7 @@ fn parse_dependency(name: String, value: &toml::Value) -> Result<Dependency, Par
     let deny_policies = DenyPolicies::new(parse_policies(value, "deny_policies")?);
 
     let rules = Rules {
+        root,
         prune,
         transitive,
         content_roots,
@@ -830,6 +856,7 @@ mod tests {
                 protocol = "https"
                 url = "github.com/org/repo"
                 revision = "1.0.0"
+                root = "/apis/users"
                 prune = true
                 content_roots = ["src"]
                 allow_policies = ["/foo/proto/file.proto", "/foo/other/*", "*/some/path/*", "re://_(?:test|unittest)\\.proto"]
@@ -851,6 +878,7 @@ mod tests {
                     branch: None,
                 },
                 rules: Rules {
+                    root: Some(DependencyRoot::from_string("/apis/users")),
                     prune: true,
                     content_roots: BTreeSet::from([ContentRoot::from_string("src")]),
                     transitive: false,

--- a/src/model/protofetch/resolved.rs
+++ b/src/model/protofetch/resolved.rs
@@ -31,21 +31,22 @@ impl ResolvedDependency {
         !self.rules.is_empty() && self.rules.iter().all(|r| r.transitive)
     }
 
-    pub fn all_content_roots(&self) -> impl Iterator<Item = &ContentRoot> {
-        self.rules.iter().flat_map(|r| r.content_roots.iter())
-    }
-
     /// Returns true if `path` (pre-zoom, relative to the dep's cache dir) is
     /// accepted by at least one occurrence's (allow ∧ ¬deny) policy after
     /// zooming with that occurrence's content roots.
     /// An empty `rules` means no filtering — allow all.
     pub fn is_file_allowed(&self, path: &Path) -> bool {
         self.rules.is_empty()
-            || self.rules.iter().any(|rules| {
-                let zoomed = zoom_in_content_roots(&rules.content_roots, path);
-                AllowPolicies::should_allow_file(&rules.allow_policies, &zoomed)
-                    && !DenyPolicies::should_deny_file(&rules.deny_policies, &zoomed)
-            })
+            || self
+                .rules
+                .iter()
+                .any(|rules| Self::is_file_allowed_by_rules(rules, path))
+    }
+
+    pub fn is_file_allowed_by_rules(rules: &Rules, path: &Path) -> bool {
+        let zoomed = zoom_in_content_roots(&rules.content_roots, path);
+        AllowPolicies::should_allow_file(&rules.allow_policies, &zoomed)
+            && !DenyPolicies::should_deny_file(&rules.deny_policies, &zoomed)
     }
 }
 

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -16,7 +16,7 @@ use crate::{
     git::coord_locks::CoordinateLocks,
     model::protofetch::{
         resolved::{ResolvedDependency, ResolvedModule},
-        ModuleName,
+        DependencyRoot, ModuleName, Rules,
     },
     sync::Semaphore,
 };
@@ -57,7 +57,11 @@ fn process_one_dep<C: RepositoryCache + ?Sized>(
     dep: &ResolvedDependency,
 ) -> Result<(), ProtoError> {
     let dep_cache_dir = cache
-        .create_worktree(&dep.coordinate, &dep.commit_hash)
+        .create_worktree(
+            &dep.coordinate,
+            &dep.commit_hash,
+            &repository_roots_for_dep(dep),
+        )
         .map_err(ProtoError::Cache)?;
     let sources_to_copy: HashSet<ProtoFileMapping> = if !dep.is_pruned() {
         copy_all_proto_files_for_dep(&dep_cache_dir, dep)?
@@ -127,21 +131,12 @@ fn copy_all_proto_files_for_dep(
     dep_cache_dir: &Path,
     dep: &ResolvedDependency,
 ) -> Result<HashSet<ProtoFileMapping>, ProtoError> {
-    let proto_files = find_proto_files(dep_cache_dir)?;
+    let proto_files = filtered_proto_files_for_rules(dep_cache_dir, dep, true)?;
     let mut proto_mapping = HashSet::with_capacity(proto_files.len());
     for proto_file_source in proto_files {
-        let proto_src = path_strip_prefix(&proto_file_source, dep_cache_dir)?;
-        if !dep.is_file_allowed(&proto_src) {
-            trace!(
-                "Filtering out proto file {} based on allow_policies rules.",
-                &proto_file_source.to_string_lossy()
-            );
-            continue;
-        }
-        let proto_package_path = zoom_in_content_root(dep, &proto_src)?;
         proto_mapping.insert(ProtoFileMapping {
-            from: proto_src,
-            to: proto_package_path,
+            from: path_strip_prefix(&proto_file_source.full_path, dep_cache_dir)?,
+            to: proto_file_source.package_path,
         });
     }
     Ok(proto_mapping.into_iter().collect())
@@ -184,10 +179,13 @@ fn pruned_transitive_dependencies<C: RepositoryCache + ?Sized>(
         found_proto_deps: &mut HashSet<ProtoFileCanonicalMapping>,
     ) -> Result<(), ProtoError> {
         let dep_dir = cache
-            .create_worktree(&dep.coordinate, &dep.commit_hash)
+            .create_worktree(
+                &dep.coordinate,
+                &dep.commit_hash,
+                &repository_roots_for_dep(dep),
+            )
             .map_err(ProtoError::Cache)?;
-        let proto_files = find_proto_files(&dep_dir)?;
-        let filtered_mapping = filtered_proto_files(proto_files, &dep_dir, dep, false)
+        let filtered_mapping = filtered_proto_files_for_rules(&dep_dir, dep, false)?
             .into_iter()
             .collect();
         let file_dependencies: HashSet<ProtoFileCanonicalMapping> = found_proto_deps
@@ -211,10 +209,13 @@ fn pruned_transitive_dependencies<C: RepositoryCache + ?Sized>(
     debug!("Extracting proto files for {}", &dep.name);
 
     let dep_dir = cache
-        .create_worktree(&dep.coordinate, &dep.commit_hash)
+        .create_worktree(
+            &dep.coordinate,
+            &dep.commit_hash,
+            &repository_roots_for_dep(dep),
+        )
         .map_err(ProtoError::Cache)?;
-    let proto_files = find_proto_files(&dep_dir)?;
-    let filtered_mapping = filtered_proto_files(proto_files, &dep_dir, dep, true);
+    let filtered_mapping = filtered_proto_files_for_rules(&dep_dir, dep, true)?;
     trace!("Filtered size {:?}.", &filtered_mapping.len());
     for mapping in filtered_mapping {
         process_mapping_file(
@@ -361,28 +362,33 @@ fn collect_all_root_dependencies(resolved: &ResolvedModule) -> Vec<ResolvedDepen
     deps
 }
 
-/// This is removing the prefix which is needed to actually load file to extract protos from imports
-fn filtered_proto_files(
-    proto_files: Vec<PathBuf>,
+/// This is removing the root prefix which is needed to actually load file to extract protos from imports.
+fn filtered_proto_files_for_rules(
     dep_dir: &Path,
     dep: &ResolvedDependency,
     should_filter: bool,
-) -> Vec<ProtoFileCanonicalMapping> {
-    proto_files
-        .into_iter()
-        .filter_map(|p| {
-            let path = path_strip_prefix(&p, dep_dir).ok()?;
-            let zoom = zoom_in_content_root(dep, &path).ok()?;
-            if dep.is_file_allowed(&path) || !should_filter {
-                Some(ProtoFileCanonicalMapping {
-                    full_path: p,
-                    package_path: zoom,
-                })
-            } else {
-                None
+) -> Result<Vec<ProtoFileCanonicalMapping>, ProtoError> {
+    let mut result = Vec::new();
+    for rules in rules_for_dep(dep) {
+        let source_dir = source_root_dir(dep_dir, &rules);
+        let proto_files = find_proto_files(&source_dir)?;
+        for proto_file in proto_files {
+            let path = path_strip_prefix(&proto_file, &source_dir)?;
+            if should_filter && !ResolvedDependency::is_file_allowed_by_rules(&rules, &path) {
+                trace!(
+                    "Filtering out proto file {} based on allow_policies rules.",
+                    proto_file.to_string_lossy()
+                );
+                continue;
             }
-        })
-        .collect()
+            let zoom = zoom_in_content_root(&rules, &path)?;
+            result.push(ProtoFileCanonicalMapping {
+                full_path: proto_file,
+                package_path: zoom,
+            });
+        }
+    }
+    Ok(result)
 }
 
 /// Takes a slice of proto files, cache source directory and a slice of dependencies associated with these files
@@ -407,13 +413,9 @@ fn canonical_mapping_for_proto_files<C: RepositoryCache + ?Sized>(
 }
 
 /// Remove content_root part of path if found
-fn zoom_in_content_root(
-    dep: &ResolvedDependency,
-    proto_file_source: &Path,
-) -> Result<PathBuf, ProtoError> {
+fn zoom_in_content_root(rules: &Rules, proto_file_source: &Path) -> Result<PathBuf, ProtoError> {
     let mut proto_src = proto_file_source.to_path_buf();
-    // Collect content roots from all rules entries (union, longest-first via rev).
-    let mut all_roots: Vec<_> = dep.all_content_roots().collect();
+    let mut all_roots: Vec<_> = rules.content_roots.iter().collect();
     if !all_roots.is_empty() {
         all_roots.sort_by_key(|r| r.value.as_os_str().len());
         let root = all_roots
@@ -440,22 +442,60 @@ fn zoom_out_content_root<C: RepositoryCache + ?Sized>(
     let mut proto_src = proto_file_source.to_path_buf();
     for dep in deps {
         let dep_dir = cache
-            .create_worktree(&dep.coordinate, &dep.commit_hash)
+            .create_worktree(
+                &dep.coordinate,
+                &dep.commit_hash,
+                &repository_roots_for_dep(dep),
+            )
             .map_err(ProtoError::Cache)?;
-        let proto_files = find_proto_files(&dep_dir)?;
-        if let Some(path) = proto_files
-            .into_iter()
-            .find(|p| p.ends_with(proto_file_source))
-        {
-            trace!(
-                "[Zoom out] Found path root {} for {}.",
-                path.to_string_lossy(),
-                proto_file_source.to_string_lossy()
-            );
-            proto_src = path;
+        for rules in rules_for_dep(dep) {
+            let source_dir = source_root_dir(&dep_dir, &rules);
+            let proto_files = find_proto_files(&source_dir)?;
+            if let Some(path) = proto_files.into_iter().find(|path| {
+                path_strip_prefix(path, &source_dir)
+                    .ok()
+                    .and_then(|path| zoom_in_content_root(&rules, &path).ok())
+                    .is_some_and(|path| {
+                        path == proto_file_source || path.ends_with(proto_file_source)
+                    })
+            }) {
+                trace!(
+                    "[Zoom out] Found path root {} for {}.",
+                    path.to_string_lossy(),
+                    proto_file_source.to_string_lossy()
+                );
+                proto_src = path;
+            }
         }
     }
     Ok(proto_src)
+}
+
+fn rules_for_dep(dep: &ResolvedDependency) -> Vec<Rules> {
+    if dep.rules.is_empty() {
+        vec![Rules::default()]
+    } else {
+        dep.rules.clone()
+    }
+}
+
+fn repository_roots_for_dep(dep: &ResolvedDependency) -> Vec<DependencyRoot> {
+    rules_for_dep(dep)
+        .into_iter()
+        .map(|rules| {
+            rules
+                .root
+                .unwrap_or_else(|| DependencyRoot::from_string(""))
+        })
+        .collect()
+}
+
+fn source_root_dir(dep_dir: &Path, rules: &Rules) -> PathBuf {
+    rules
+        .root
+        .as_ref()
+        .map(|root| dep_dir.join(&root.value))
+        .unwrap_or_else(|| dep_dir.to_path_buf())
 }
 
 fn path_strip_prefix(path: &Path, prefix: &Path) -> Result<PathBuf, ProtoError> {
@@ -500,6 +540,7 @@ mod tests {
             &self,
             coordinate: &Coordinate,
             commit_hash: &str,
+            _roots: &[DependencyRoot],
         ) -> anyhow::Result<PathBuf> {
             Ok(self.root.join(coordinate.to_path()).join(commit_hash))
         }

--- a/src/resolver/git.rs
+++ b/src/resolver/git.rs
@@ -1,6 +1,6 @@
 use crate::{
     git::cache::ProtofetchGitCache,
-    model::protofetch::{Coordinate, ModuleName, RevisionSpecification},
+    model::protofetch::{Coordinate, DependencyRoot, ModuleName, RevisionSpecification},
 };
 
 use super::{CommitAndDescriptor, ModuleResolver};
@@ -12,6 +12,7 @@ impl ModuleResolver for ProtofetchGitCache {
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
         name: &ModuleName,
+        root: Option<&DependencyRoot>,
     ) -> anyhow::Result<CommitAndDescriptor> {
         let repository = self.repository(coordinate)?;
         let commit_hash = if let Some(commit_hash) = commit_hash {
@@ -21,7 +22,7 @@ impl ModuleResolver for ProtofetchGitCache {
             repository.fetch(specification)?;
             repository.resolve_commit_hash(specification)?
         };
-        let descriptor = repository.extract_descriptor(name, &commit_hash)?;
+        let descriptor = repository.extract_descriptor(name, &commit_hash, root)?;
         Ok(CommitAndDescriptor {
             commit_hash,
             descriptor,

--- a/src/resolver/lock.rs
+++ b/src/resolver/lock.rs
@@ -3,7 +3,7 @@ use log::debug;
 
 use crate::model::protofetch::{
     lock::{LockFile, LockedCoordinate},
-    Coordinate, ModuleName, RevisionSpecification,
+    Coordinate, DependencyRoot, ModuleName, RevisionSpecification,
 };
 
 use super::{CommitAndDescriptor, ModuleResolver};
@@ -34,6 +34,7 @@ where
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
         name: &ModuleName,
+        root: Option<&DependencyRoot>,
     ) -> anyhow::Result<CommitAndDescriptor> {
         let locked_coordinate = LockedCoordinate::from(coordinate);
         let dependency = self.lock_file.dependencies.iter().find(|dependency| {
@@ -50,6 +51,7 @@ where
                     specification,
                     commit_hash.or(Some(&dependency.commit_hash)),
                     name,
+                    root,
                 )?;
                 if resolved.commit_hash != dependency.commit_hash {
                     bail!(
@@ -75,7 +77,7 @@ where
                     coordinate, specification
                 );
                 self.inner
-                    .resolve(coordinate, specification, commit_hash, name)
+                    .resolve(coordinate, specification, commit_hash, name, root)
             }
         }
     }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -3,7 +3,9 @@ mod lock;
 
 use std::sync::Arc;
 
-use crate::model::protofetch::{Coordinate, Descriptor, ModuleName, RevisionSpecification};
+use crate::model::protofetch::{
+    Coordinate, DependencyRoot, Descriptor, ModuleName, RevisionSpecification,
+};
 
 pub use lock::LockFileModuleResolver;
 
@@ -14,6 +16,7 @@ pub trait ModuleResolver: Send + Sync {
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
         name: &ModuleName,
+        root: Option<&DependencyRoot>,
     ) -> anyhow::Result<CommitAndDescriptor>;
 }
 
@@ -33,8 +36,9 @@ where
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
         name: &ModuleName,
+        root: Option<&DependencyRoot>,
     ) -> anyhow::Result<CommitAndDescriptor> {
-        T::resolve(self, coordinate, specification, commit_hash, name)
+        T::resolve(self, coordinate, specification, commit_hash, name, root)
     }
 }
 
@@ -48,7 +52,8 @@ where
         specification: &RevisionSpecification,
         commit_hash: Option<&str>,
         name: &ModuleName,
+        root: Option<&DependencyRoot>,
     ) -> anyhow::Result<CommitAndDescriptor> {
-        T::resolve(self, coordinate, specification, commit_hash, name)
+        T::resolve(self, coordinate, specification, commit_hash, name, root)
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -307,6 +307,187 @@ fn fetch_content_roots() {
     assert_snapshot!("content_roots_output", result.snapshot_tree());
 }
 
+/// With root set, protofetch loads the dependency descriptor from that
+/// subdirectory and copies files relative to it.
+#[test]
+fn fetch_dependency_root_loads_nested_descriptor() {
+    let mut world = TestWorld::new();
+
+    world.create_repo(
+        "org/repo2",
+        &[(
+            "dep.proto",
+            indoc! {r#"
+                syntax = "proto3";
+                message Dep {}
+            "#},
+        )],
+    );
+
+    world.create_repo(
+        "org/repo1",
+        &[
+            (
+                "service/protofetch.toml",
+                indoc! {r#"
+                    name = "repo1"
+
+                    [repo2]
+                    url = "<base>/org/repo2"
+                    protocol = "file"
+                    branch = "main"
+                "#},
+            ),
+            (
+                "service/api.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Api {}
+                "#},
+            ),
+            (
+                "outside.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Outside {}
+                "#},
+            ),
+        ],
+    );
+
+    let result = world.fetch(toml! {
+        name = "e2e-test"
+
+        [repo1]
+        url = "org/repo1"
+        branch = "main"
+        root = "service"
+    });
+
+    assert_snapshot!(
+        "dependency_root_nested_descriptor_output",
+        result.snapshot_tree()
+    );
+    assert_snapshot!(
+        "dependency_root_nested_descriptor_lockfile",
+        result.snapshot_lockfile()
+    );
+}
+
+/// root is the base for content_roots and policies; the root prefix itself is
+/// not copied into the output tree.
+#[test]
+fn fetch_dependency_root_scopes_content_roots_and_policies() {
+    let mut world = TestWorld::new();
+
+    world.create_repo(
+        "org/repo1",
+        &[
+            (
+                "api/proto/allowed/service.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Service {}
+                "#},
+            ),
+            (
+                "api/proto/denied/internal.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Internal {}
+                "#},
+            ),
+            (
+                "other.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Other {}
+                "#},
+            ),
+        ],
+    );
+
+    let result = world.fetch(toml! {
+        name = "e2e-test"
+
+        [repo1]
+        url = "org/repo1"
+        branch = "main"
+        root = "api"
+        content_roots = ["proto"]
+        allow_policies = ["allowed/*"]
+    });
+
+    assert_snapshot!(
+        "dependency_root_scoped_rules_output",
+        result.snapshot_tree()
+    );
+}
+
+/// The same repository can be used as multiple dependencies with different roots.
+#[test]
+fn fetch_dependency_root_merged_across_duplicate_deps() {
+    let mut world = TestWorld::new();
+
+    world.create_repo(
+        "org/shared",
+        &[
+            (
+                "dep1/protofetch.toml",
+                indoc! {r#"
+                    name = "dep1"
+                "#},
+            ),
+            (
+                "dep1/dep1.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Dep1 {}
+                "#},
+            ),
+            (
+                "dep2/protofetch.toml",
+                indoc! {r#"
+                    name = "dep2"
+                "#},
+            ),
+            (
+                "dep2/dep2.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Dep2 {}
+                "#},
+            ),
+            (
+                "outside.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Outside {}
+                "#},
+            ),
+        ],
+    );
+
+    let result = world.fetch(toml! {
+        name = "e2e-test"
+
+        [dep1]
+        url = "org/shared"
+        branch = "main"
+        root = "dep1"
+
+        [dep2]
+        url = "org/shared"
+        branch = "main"
+        root = "dep2"
+    });
+
+    assert_snapshot!(
+        "dependency_root_merged_duplicate_deps_output",
+        result.snapshot_tree()
+    );
+}
+
 /// deny_policies is the mirror of allow_policies: matching files are excluded.
 /// `deny_policies = ["internal/*"]` removes everything under internal/.
 #[test]

--- a/tests/snapshots/e2e__dependency_root_merged_duplicate_deps_output.snap
+++ b/tests/snapshots/e2e__dependency_root_merged_duplicate_deps_output.snap
@@ -1,0 +1,11 @@
+---
+source: tests/e2e.rs
+expression: result.snapshot_tree()
+---
+=== dep1.proto ===
+syntax = "proto3";
+message Dep1 {}
+
+=== dep2.proto ===
+syntax = "proto3";
+message Dep2 {}

--- a/tests/snapshots/e2e__dependency_root_nested_descriptor_lockfile.snap
+++ b/tests/snapshots/e2e__dependency_root_nested_descriptor_lockfile.snap
@@ -1,0 +1,19 @@
+---
+source: tests/e2e.rs
+expression: result.snapshot_lockfile()
+---
+version = 2
+
+[[dependencies]]
+name = "repo1"
+url = "<base>/org/repo1"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:2>"
+
+[[dependencies]]
+name = "repo2"
+url = "<base>/org/repo2"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:1>"

--- a/tests/snapshots/e2e__dependency_root_nested_descriptor_output.snap
+++ b/tests/snapshots/e2e__dependency_root_nested_descriptor_output.snap
@@ -1,0 +1,11 @@
+---
+source: tests/e2e.rs
+expression: result.snapshot_tree()
+---
+=== api.proto ===
+syntax = "proto3";
+message Api {}
+
+=== dep.proto ===
+syntax = "proto3";
+message Dep {}

--- a/tests/snapshots/e2e__dependency_root_scoped_rules_output.snap
+++ b/tests/snapshots/e2e__dependency_root_scoped_rules_output.snap
@@ -1,0 +1,7 @@
+---
+source: tests/e2e.rs
+expression: result.snapshot_tree()
+---
+=== allowed/service.proto ===
+syntax = "proto3";
+message Service {}


### PR DESCRIPTION
Currently, protofetch required `protofetch.toml` to be in the root of the repository.
This is not particularly friendly to the cases when proto files are only a part of what's in the repository, and does not work at all if we want to have more than one protofetch module in one repository.

This PR adds a new optional `root` field to the dependency definition in the module descriptor. When set, it is treated as if it was the root of the repository — the descriptor is loaded from this path, content roots and policy settings apply relatively to the root.

While `root` looks similar to `content_roots`, I don't think we could get away with something like just loading additional descriptors from all specified `content_roots`. Unlike the new setting, `content_roots` does not apply any filter to the files, it only makes protofetch remove the prefix from matching files, but proto files outside of the content roots are still included.

I also considered making `root` a part of the URL, but there is no common way to do so. The most natural approach would probably be `github.com/org/repo/path` but this makes URL invalid when open in a browser, which could be confusing.

The change is not forward compatible: old protofetch versions will ignore the `root` field, fetching wrong protos (or most likely rather not fetching the right ones). I'm not sure if we have a good way to deal with such incompatibilities though. Maybe we can bump a version in the lockfile — it won't fix all issues, but at least we will make sure that `protofetch fetch --locked` always produces the same results.