### PR TITLE
ci: publish per-PR preview packages to pkg.pr.new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,54 @@ jobs:
           pnpm add ../packed/*.tgz
           ./node_modules/.bin/protofetch --version
 
+  # Per-PR preview packages via pkg.pr.new (no git tags / GitHub Releases).
+  #
+  # The main package + all five platform packages MUST publish in ONE invocation
+  # of dist DIRECTORIES (not .tgz): pkg.pr.new only rewrites optionalDependencies
+  # to the preview URLs for sibling packages in the same call, and tarballs are
+  # uploaded as-is without rewriting. The cx-protofetch mirror is skipped
+  # (deprecated).
+  preview-publish:
+    name: pkg.pr.new
+    needs: [ package ]
+    if: github.repository == 'coralogix/protofetch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: package-*
+          path: artifacts
+          merge-multiple: true
+
+      - name: Prepare npm packages
+        run: |
+          node .github/npm/prepare-package.js --target main
+          for rust in \
+            aarch64-apple-darwin \
+            x86_64-apple-darwin \
+            aarch64-unknown-linux-musl \
+            x86_64-unknown-linux-musl \
+            x86_64-pc-windows-msvc; do
+            node .github/npm/prepare-package.js --target platform --rust "$rust" --artifacts artifacts
+          done
+
+      - name: Publish preview packages
+        run: |
+          npx pkg-pr-new@0.0.75 publish --comment=update --no-template \
+            ./.github/npm/dist/coralogix-protofetch \
+            ./.github/npm/dist/platform/*
+
   release:
     if: github.repository == 'coralogix/protofetch' && startsWith(github.ref, 'refs/tags/')
     needs: [ package, test-npm-package ]


### PR DESCRIPTION
Adds a `preview-publish` CI job that publishes per-commit preview packages to [pkg.pr.new](https://pkg.pr.new) on every PR.

Draft, opened against the npm-restructuring branch to validate the job end to end before retargeting master.

## What it does
- Reuses the existing `package` job's prebuilt binaries (no extra builds), runs `prepare-package.js` for the main package + all 5 platform packages, and publishes them in a single `pkg-pr-new publish` of the dist **directories**.
- Single invocation + directories (not `.tgz`) is required so the main package's `optionalDependencies` get rewritten to the per-commit preview URLs.
- Skips the deprecated `cx-protofetch` mirror; `--no-template` (native binary can't run in a StackBlitz WebContainer); compact URLs left on (auto-fall-back until packages are on npm).
- No secrets/`id-token` needed; the pkg.pr.new GitHub App authenticates and posts the PR comment.