### PR TITLE
Content root fixes

### DIFF
--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -52,13 +52,7 @@ pub fn do_fetch(
         parallel.network_jobs,
     )?;
 
-    proto::copy_proto_files_parallel(
-        cache.clone(),
-        Arc::new(resolved),
-        proto_out,
-        cache.coord_locks().clone(),
-        parallel,
-    )?;
+    proto::copy_proto_files_parallel(cache.clone(), Arc::new(resolved), proto_out, parallel)?;
 
     Ok(())
 }

--- a/src/model/protofetch/resolved.rs
+++ b/src/model/protofetch/resolved.rs
@@ -1,11 +1,6 @@
-use std::{
-    collections::BTreeSet,
-    path::{Path, PathBuf},
-};
+use std::collections::BTreeSet;
 
-use super::{
-    AllowPolicies, ContentRoot, Coordinate, DenyPolicies, ModuleName, RevisionSpecification, Rules,
-};
+use super::{Coordinate, ModuleName, RevisionSpecification, Rules};
 
 pub struct ResolvedModule {
     pub module_name: ModuleName,
@@ -30,35 +25,4 @@ impl ResolvedDependency {
     pub fn is_transitive(&self) -> bool {
         !self.rules.is_empty() && self.rules.iter().all(|r| r.transitive)
     }
-
-    pub fn all_content_roots(&self) -> impl Iterator<Item = &ContentRoot> {
-        self.rules.iter().flat_map(|r| r.content_roots.iter())
-    }
-
-    /// Returns true if `path` (pre-zoom, relative to the dep's cache dir) is
-    /// accepted by at least one occurrence's (allow ∧ ¬deny) policy after
-    /// zooming with that occurrence's content roots.
-    /// An empty `rules` means no filtering — allow all.
-    pub fn is_file_allowed(&self, path: &Path) -> bool {
-        self.rules.is_empty()
-            || self.rules.iter().any(|rules| {
-                let zoomed = zoom_in_content_roots(&rules.content_roots, path);
-                AllowPolicies::should_allow_file(&rules.allow_policies, &zoomed)
-                    && !DenyPolicies::should_deny_file(&rules.deny_policies, &zoomed)
-            })
-    }
-}
-
-fn zoom_in_content_roots(content_roots: &BTreeSet<ContentRoot>, path: &Path) -> PathBuf {
-    if content_roots.is_empty() {
-        return path.to_path_buf();
-    }
-    // Reverse iteration gives priority to longer (more specific) content roots.
-    content_roots
-        .iter()
-        .rev()
-        .find(|r| path.starts_with(&r.value))
-        .and_then(|r| path.strip_prefix(&r.value).ok())
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| path.to_path_buf())
 }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -16,7 +16,7 @@ use crate::{
     git::coord_locks::CoordinateLocks,
     model::protofetch::{
         resolved::{ResolvedDependency, ResolvedModule},
-        ModuleName,
+        AllowPolicies, DenyPolicies, ModuleName, Rules,
     },
     sync::Semaphore,
 };
@@ -64,11 +64,7 @@ fn process_one_dep<C: RepositoryCache + ?Sized>(
     } else {
         pruned_transitive_dependencies(cache, dep, resolved)?
     };
-    let without_denied_files = sources_to_copy
-        .into_iter()
-        .filter(|m| dep.is_file_allowed(&m.to))
-        .collect();
-    copy_proto_sources_for_dep(proto_dir, &dep_cache_dir, dep, &without_denied_files)?;
+    copy_proto_sources_for_dep(proto_dir, &dep_cache_dir, dep, &sources_to_copy)?;
     Ok(())
 }
 
@@ -131,18 +127,21 @@ fn copy_all_proto_files_for_dep(
     let mut proto_mapping = HashSet::with_capacity(proto_files.len());
     for proto_file_source in proto_files {
         let proto_src = path_strip_prefix(&proto_file_source, dep_cache_dir)?;
-        if !dep.is_file_allowed(&proto_src) {
-            trace!(
-                "Filtering out proto file {} based on allow_policies rules.",
-                &proto_file_source.to_string_lossy()
-            );
-            continue;
+        let rules = rules_for_dep(dep);
+        for rules in rules {
+            let proto_package_path = zoom_in_content_root(&rules, &proto_src)?;
+            if !is_file_allowed_by_rule(&rules, &proto_package_path) {
+                trace!(
+                    "Filtering out proto file {} based on allow_policies rules.",
+                    &proto_file_source.to_string_lossy()
+                );
+                continue;
+            }
+            proto_mapping.insert(ProtoFileMapping {
+                from: proto_src.clone(),
+                to: proto_package_path,
+            });
         }
-        let proto_package_path = zoom_in_content_root(dep, &proto_src)?;
-        proto_mapping.insert(ProtoFileMapping {
-            from: proto_src,
-            to: proto_package_path,
-        });
     }
     Ok(proto_mapping.into_iter().collect())
 }
@@ -370,17 +369,25 @@ fn filtered_proto_files(
 ) -> Vec<ProtoFileCanonicalMapping> {
     proto_files
         .into_iter()
-        .filter_map(|p| {
-            let path = path_strip_prefix(&p, dep_dir).ok()?;
-            let zoom = zoom_in_content_root(dep, &path).ok()?;
-            if dep.is_file_allowed(&path) || !should_filter {
-                Some(ProtoFileCanonicalMapping {
-                    full_path: p,
-                    package_path: zoom,
+        .flat_map(|p| {
+            let path = match path_strip_prefix(&p, dep_dir) {
+                Ok(path) => path,
+                Err(_) => return Vec::new(),
+            };
+            rules_for_dep(dep)
+                .into_iter()
+                .filter_map(|rules| {
+                    let zoom = zoom_in_content_root(&rules, &path).ok()?;
+                    if is_file_allowed_by_rule(&rules, &zoom) || !should_filter {
+                        Some(ProtoFileCanonicalMapping {
+                            full_path: p.clone(),
+                            package_path: zoom,
+                        })
+                    } else {
+                        None
+                    }
                 })
-            } else {
-                None
-            }
+                .collect::<Vec<_>>()
         })
         .collect()
 }
@@ -407,17 +414,13 @@ fn canonical_mapping_for_proto_files<C: RepositoryCache + ?Sized>(
 }
 
 /// Remove content_root part of path if found
-fn zoom_in_content_root(
-    dep: &ResolvedDependency,
-    proto_file_source: &Path,
-) -> Result<PathBuf, ProtoError> {
+fn zoom_in_content_root(rules: &Rules, proto_file_source: &Path) -> Result<PathBuf, ProtoError> {
     let mut proto_src = proto_file_source.to_path_buf();
-    // Collect content roots from all rules entries (union, longest-first via rev).
-    let mut all_roots: Vec<_> = dep.all_content_roots().collect();
-    if !all_roots.is_empty() {
-        all_roots.sort_by_key(|r| r.value.as_os_str().len());
-        let root = all_roots
-            .iter()
+    if !rules.content_roots.is_empty() {
+        let mut content_roots: Vec<_> = rules.content_roots.iter().collect();
+        content_roots.sort_by_key(|r| r.value.as_os_str().len());
+        let root = content_roots
+            .into_iter()
             .rev()
             .find(|c_root| proto_file_source.starts_with(&c_root.value));
         if let Some(c_root) = root {
@@ -430,6 +433,19 @@ fn zoom_in_content_root(
         }
     }
     Ok(proto_src)
+}
+
+fn rules_for_dep(dep: &ResolvedDependency) -> Vec<Rules> {
+    if dep.rules.is_empty() {
+        vec![Rules::default()]
+    } else {
+        dep.rules.clone()
+    }
+}
+
+fn is_file_allowed_by_rule(rules: &Rules, path: &Path) -> bool {
+    AllowPolicies::should_allow_file(&rules.allow_policies, path)
+        && !DenyPolicies::should_deny_file(&rules.deny_policies, path)
 }
 
 fn zoom_out_content_root<C: RepositoryCache + ?Sized>(

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fs::File,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
@@ -7,7 +7,7 @@ use std::{
     thread,
 };
 
-use log::{debug, info, trace};
+use log::{debug, info, trace, warn};
 use thiserror::Error;
 
 use crate::{
@@ -36,6 +36,15 @@ pub enum ProtoError {
 struct ProtoFileMapping {
     from: PathBuf,
     to: PathBuf,
+    rule_order: usize,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedProtoCopy {
+    dep: ResolvedDependency,
+    dep_cache_dir: PathBuf,
+    mapping: ProtoFileMapping,
+    dep_order: usize,
 }
 
 /// Proto file canonical representation
@@ -53,19 +62,19 @@ struct ProtoFileCanonicalMapping {
 fn process_one_dep<C: RepositoryCache + ?Sized>(
     cache: &C,
     resolved: &ResolvedModule,
-    proto_dir: &Path,
     dep: &ResolvedDependency,
-) -> Result<(), ProtoError> {
+) -> Result<(PathBuf, Vec<ProtoFileMapping>), ProtoError> {
     let dep_cache_dir = cache
         .create_worktree(&dep.coordinate, &dep.commit_hash)
         .map_err(ProtoError::Cache)?;
-    let sources_to_copy: HashSet<ProtoFileMapping> = if !dep.is_pruned() {
+    let sources_to_copy = if !dep.is_pruned() {
         copy_all_proto_files_for_dep(&dep_cache_dir, dep)?
     } else {
         pruned_transitive_dependencies(cache, dep, resolved)?
+            .into_iter()
+            .collect()
     };
-    copy_proto_sources_for_dep(proto_dir, &dep_cache_dir, dep, &sources_to_copy)?;
-    Ok(())
+    Ok((dep_cache_dir, sources_to_copy))
 }
 
 /// Sequential per-dep work runs across `parallel.copy_jobs` worker threads
@@ -93,28 +102,53 @@ where
     let deps = collect_all_root_dependencies(&resolved);
     let disk_sem = Semaphore::new(parallel.copy_jobs.max(1));
 
-    thread::scope(|s| -> Result<(), ProtoError> {
+    let mut planned = thread::scope(|s| -> Result<Vec<PlannedProtoCopy>, ProtoError> {
         let mut handles = Vec::with_capacity(deps.len());
-        for dep in deps {
+        for (dep_order, dep) in deps.into_iter().enumerate() {
             let cache = cache.clone();
             let resolved = resolved.clone();
-            let proto_dir = proto_dir.clone();
             let disk_sem = &disk_sem;
             let coord_lock = coord_locks.lock_for(&dep.coordinate);
             handles.push(s.spawn(move || {
                 let _permit = disk_sem.acquire();
                 let _g = coord_lock.lock().expect("coord lock poisoned");
-                process_one_dep(&cache, &resolved, &proto_dir, &dep)
+                let (dep_cache_dir, sources_to_copy) = process_one_dep(&cache, &resolved, &dep)?;
+                Ok::<_, ProtoError>(
+                    sources_to_copy
+                        .into_iter()
+                        .map(|mapping| PlannedProtoCopy {
+                            dep: dep.clone(),
+                            dep_cache_dir: dep_cache_dir.clone(),
+                            mapping,
+                            dep_order,
+                        })
+                        .collect::<Vec<_>>(),
+                )
             }));
         }
+        let mut planned = Vec::new();
         for h in handles {
             match h.join() {
-                Ok(result) => result?,
+                Ok(result) => planned.extend(result?),
                 Err(payload) => std::panic::resume_unwind(payload),
             }
         }
-        Ok(())
-    })
+        Ok(planned)
+    })?;
+
+    planned.sort_by_key(|copy| (copy.dep_order, copy.mapping.rule_order));
+    let planned = dedupe_proto_copies(planned);
+
+    for copy in planned {
+        copy_proto_sources_for_dep(
+            &proto_dir,
+            &copy.dep_cache_dir,
+            &copy.dep,
+            std::slice::from_ref(&copy.mapping),
+        )?;
+    }
+
+    Ok(())
 }
 
 /// Copy all proto files for a dependency to the proto_dir
@@ -122,28 +156,29 @@ where
 fn copy_all_proto_files_for_dep(
     dep_cache_dir: &Path,
     dep: &ResolvedDependency,
-) -> Result<HashSet<ProtoFileMapping>, ProtoError> {
+) -> Result<Vec<ProtoFileMapping>, ProtoError> {
     let proto_files = find_proto_files(dep_cache_dir)?;
-    let mut proto_mapping = HashSet::with_capacity(proto_files.len());
+    let mut proto_mapping = Vec::with_capacity(proto_files.len());
+    let rules = rules_for_dep(dep);
     for proto_file_source in proto_files {
         let proto_src = path_strip_prefix(&proto_file_source, dep_cache_dir)?;
-        let rules = rules_for_dep(dep);
-        for rules in rules {
-            let proto_package_path = zoom_in_content_root(&rules, &proto_src)?;
-            if !is_file_allowed_by_rule(&rules, &proto_package_path) {
+        for (rule_order, rules) in rules.iter().enumerate() {
+            let proto_package_path = zoom_in_content_root(rules, &proto_src)?;
+            if !is_file_allowed_by_rule(rules, &proto_package_path) {
                 trace!(
                     "Filtering out proto file {} based on allow_policies rules.",
                     &proto_file_source.to_string_lossy()
                 );
                 continue;
             }
-            proto_mapping.insert(ProtoFileMapping {
+            proto_mapping.push(ProtoFileMapping {
                 from: proto_src.clone(),
                 to: proto_package_path,
+                rule_order,
             });
         }
     }
-    Ok(proto_mapping.into_iter().collect())
+    Ok(proto_mapping)
 }
 
 /// Returns a HashSet of ProtoFileMapping to the proto files that `dep` depends on. It recursively
@@ -248,15 +283,39 @@ fn pruned_transitive_dependencies<C: RepositoryCache + ?Sized>(
         .map(|p| ProtoFileMapping {
             from: p.full_path,
             to: p.package_path,
+            rule_order: 0,
         })
         .collect())
+}
+
+fn dedupe_proto_copies(planned: Vec<PlannedProtoCopy>) -> Vec<PlannedProtoCopy> {
+    let mut planned_by_source: HashMap<PathBuf, PlannedProtoCopy> = HashMap::new();
+    for copy in planned {
+        let source = copy.dep_cache_dir.join(&copy.mapping.from);
+        match planned_by_source.entry(source) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(copy);
+            }
+            std::collections::hash_map::Entry::Occupied(entry) => {
+                if entry.get().mapping.to != copy.mapping.to {
+                    warn!(
+                        "discarded {} for {} in favor of {}",
+                        copy.mapping.to.to_string_lossy(),
+                        copy.dep.name,
+                        entry.get().mapping.to.to_string_lossy()
+                    );
+                }
+            }
+        }
+    }
+    planned_by_source.into_values().collect()
 }
 
 fn copy_proto_sources_for_dep(
     proto_dir: &Path,
     dep_cache_dir: &Path,
     dep: &ResolvedDependency,
-    sources_to_copy: &HashSet<ProtoFileMapping>,
+    sources_to_copy: &[ProtoFileMapping],
 ) -> Result<(), ProtoError> {
     debug!(
         "Copying {:?} proto files for dependency {}",

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -3,7 +3,7 @@ use std::{
     fs::File,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
     thread,
 };
 
@@ -13,12 +13,10 @@ use thiserror::Error;
 use crate::{
     cache::RepositoryCache,
     fetch::ParallelConfig,
-    git::coord_locks::CoordinateLocks,
     model::protofetch::{
         resolved::{ResolvedDependency, ResolvedModule},
         AllowPolicies, DenyPolicies, ModuleName, Rules,
     },
-    sync::Semaphore,
 };
 
 #[derive(Error, Debug)]
@@ -77,15 +75,12 @@ fn process_one_dep<C: RepositoryCache + ?Sized>(
     Ok((dep_cache_dir, sources_to_copy))
 }
 
-/// Sequential per-dep work runs across `parallel.copy_jobs` worker threads
-/// gated by a disk semaphore so network and disk concurrency are tunable
-/// independently. The per-coord lock serializes `create_worktree` calls for
-/// deps that share an on-disk bare repo.
+/// Plans proto source mappings deterministically, then copies the resulting
+/// files across `parallel.copy_jobs` worker threads.
 pub fn copy_proto_files_parallel<C>(
     cache: C,
     resolved: Arc<ResolvedModule>,
     proto_dir: PathBuf,
-    coord_locks: CoordinateLocks,
     parallel: ParallelConfig,
 ) -> Result<(), ProtoError>
 where
@@ -100,53 +95,52 @@ where
     }
 
     let deps = collect_all_root_dependencies(&resolved);
-    let disk_sem = Semaphore::new(parallel.copy_jobs.max(1));
-
-    let mut planned = thread::scope(|s| -> Result<Vec<PlannedProtoCopy>, ProtoError> {
-        let mut handles = Vec::with_capacity(deps.len());
-        for (dep_order, dep) in deps.into_iter().enumerate() {
-            let cache = cache.clone();
-            let resolved = resolved.clone();
-            let disk_sem = &disk_sem;
-            let coord_lock = coord_locks.lock_for(&dep.coordinate);
-            handles.push(s.spawn(move || {
-                let _permit = disk_sem.acquire();
-                let _g = coord_lock.lock().expect("coord lock poisoned");
-                let (dep_cache_dir, sources_to_copy) = process_one_dep(&cache, &resolved, &dep)?;
-                Ok::<_, ProtoError>(
-                    sources_to_copy
-                        .into_iter()
-                        .map(|mapping| PlannedProtoCopy {
-                            dep: dep.clone(),
-                            dep_cache_dir: dep_cache_dir.clone(),
-                            mapping,
-                            dep_order,
-                        })
-                        .collect::<Vec<_>>(),
-                )
-            }));
-        }
-        let mut planned = Vec::new();
-        for h in handles {
-            match h.join() {
-                Ok(result) => planned.extend(result?),
-                Err(payload) => std::panic::resume_unwind(payload),
-            }
-        }
-        Ok(planned)
-    })?;
+    let mut planned = Vec::new();
+    for (dep_order, dep) in deps.into_iter().enumerate() {
+        let (dep_cache_dir, sources_to_copy) = process_one_dep(&cache, &resolved, &dep)?;
+        planned.extend(sources_to_copy.into_iter().map(|mapping| PlannedProtoCopy {
+            dep: dep.clone(),
+            dep_cache_dir: dep_cache_dir.clone(),
+            mapping,
+            dep_order,
+        }));
+    }
 
     planned.sort_by_key(|copy| (copy.dep_order, copy.mapping.rule_order));
     let planned = dedupe_proto_copies(planned);
+    let copy_jobs = parallel.copy_jobs.max(1).min(planned.len());
+    let planned = Mutex::new(planned);
 
-    for copy in planned {
-        copy_proto_sources_for_dep(
-            &proto_dir,
-            &copy.dep_cache_dir,
-            &copy.dep,
-            std::slice::from_ref(&copy.mapping),
-        )?;
-    }
+    thread::scope(|s| -> Result<(), ProtoError> {
+        let mut handles = Vec::with_capacity(copy_jobs);
+        for _ in 0..copy_jobs {
+            let proto_dir = &proto_dir;
+            let planned = &planned;
+            handles.push(s.spawn(move || {
+                loop {
+                    let copy = planned.lock().expect("copy queue poisoned").pop();
+                    let Some(copy) = copy else {
+                        break;
+                    };
+                    copy_proto_sources_for_dep(
+                        proto_dir,
+                        &copy.dep_cache_dir,
+                        &copy.dep,
+                        std::slice::from_ref(&copy.mapping),
+                    )?;
+                }
+                Ok::<_, ProtoError>(())
+            }));
+        }
+
+        for h in handles {
+            match h.join() {
+                Ok(result) => result?,
+                Err(payload) => std::panic::resume_unwind(payload),
+            }
+        }
+        Ok(())
+    })?;
 
     Ok(())
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -863,3 +863,73 @@ fn fetch_allow_policies_merged_across_duplicate_deps() {
     // Both subtrees must be present: from_root/ (root's policy) and from_foo/ (foo's policy)
     assert_snapshot!("allow_policies_merged_output", result.snapshot_tree());
 }
+
+#[test]
+fn fetch_duplicate_dep_keeps_content_roots_and_policies_coupled() {
+    let mut world = TestWorld::new();
+
+    world.create_repo(
+        "org/shared",
+        &[
+            (
+                "root/nested/foo.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Foo {}
+                "#},
+            ),
+            (
+                "root/nested/bar.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Bar {}
+                "#},
+            ),
+        ],
+    );
+
+    world.create_repo(
+        "org/consumer",
+        &[
+            (
+                "protofetch.toml",
+                indoc! {r#"
+                    name = "consumer"
+
+                    [shared]
+                    url = "<base>/org/shared"
+                    protocol = "file"
+                    branch = "main"
+                    content_roots = ["root/nested"]
+                    allow_policies = ["bar.proto"]
+                "#},
+            ),
+            (
+                "consumer.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Consumer {}
+                "#},
+            ),
+        ],
+    );
+
+    let result = world.fetch(toml! {
+        name = "e2e-test"
+
+        [shared]
+        url = "org/shared"
+        branch = "main"
+        content_roots = ["root"]
+        allow_policies = ["nested/foo.proto"]
+
+        [consumer]
+        url = "org/consumer"
+        branch = "main"
+    });
+
+    assert_snapshot!(
+        "duplicate_dep_content_roots_and_policies_output",
+        result.snapshot_tree()
+    );
+}

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -933,3 +933,62 @@ fn fetch_duplicate_dep_keeps_content_roots_and_policies_coupled() {
         result.snapshot_tree()
     );
 }
+
+#[test]
+fn fetch_duplicate_dep_same_file_under_different_content_roots() {
+    let mut world = TestWorld::new();
+
+    world.create_repo(
+        "org/shared",
+        &[(
+            "root/nested/shared.proto",
+            indoc! {r#"
+                syntax = "proto3";
+                message Shared {}
+            "#},
+        )],
+    );
+
+    world.create_repo(
+        "org/consumer",
+        &[
+            (
+                "protofetch.toml",
+                indoc! {r#"
+                    name = "consumer"
+
+                    [shared]
+                    url = "<base>/org/shared"
+                    protocol = "file"
+                    branch = "main"
+                    content_roots = ["root/nested"]
+                "#},
+            ),
+            (
+                "consumer.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Consumer {}
+                "#},
+            ),
+        ],
+    );
+
+    let result = world.fetch(toml! {
+        name = "e2e-test"
+
+        [shared]
+        url = "org/shared"
+        branch = "main"
+        content_roots = ["root"]
+
+        [consumer]
+        url = "org/consumer"
+        branch = "main"
+    });
+
+    assert_snapshot!(
+        "duplicate_dep_same_file_under_different_content_roots_output",
+        result.snapshot_tree()
+    );
+}

--- a/tests/snapshots/e2e__allow_policies_output.snap
+++ b/tests/snapshots/e2e__allow_policies_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === public/service.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__content_roots_output.snap
+++ b/tests/snapshots/e2e__content_roots_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === internal/secret.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__deny_policies_output.snap
+++ b/tests/snapshots/e2e__deny_policies_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === public/service.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__duplicate_dep_content_roots_and_policies_output.snap
+++ b/tests/snapshots/e2e__duplicate_dep_content_roots_and_policies_output.snap
@@ -1,0 +1,11 @@
+---
+source: tests/e2e.rs
+expression: result.snapshot_tree()
+---
+=== bar.proto ===
+syntax = "proto3";
+message Bar {}
+
+=== consumer.proto ===
+syntax = "proto3";
+message Consumer {}

--- a/tests/snapshots/e2e__duplicate_dep_content_roots_and_policies_output.snap
+++ b/tests/snapshots/e2e__duplicate_dep_content_roots_and_policies_output.snap
@@ -9,3 +9,7 @@ message Bar {}
 === consumer.proto ===
 syntax = "proto3";
 message Consumer {}
+
+=== nested/foo.proto ===
+syntax = "proto3";
+message Foo {}

--- a/tests/snapshots/e2e__duplicate_dep_same_file_under_different_content_roots_output.snap
+++ b/tests/snapshots/e2e__duplicate_dep_same_file_under_different_content_roots_output.snap
@@ -1,0 +1,15 @@
+---
+source: tests/e2e.rs
+expression: result.snapshot_tree()
+---
+=== consumer.proto ===
+syntax = "proto3";
+message Consumer {}
+
+=== nested/shared.proto ===
+syntax = "proto3";
+message Shared {}
+
+=== shared.proto ===
+syntax = "proto3";
+message Shared {}

--- a/tests/snapshots/e2e__duplicate_dep_same_file_under_different_content_roots_output.snap
+++ b/tests/snapshots/e2e__duplicate_dep_same_file_under_different_content_roots_output.snap
@@ -9,7 +9,3 @@ message Consumer {}
 === nested/shared.proto ===
 syntax = "proto3";
 message Shared {}
-
-=== shared.proto ===
-syntax = "proto3";
-message Shared {}

--- a/tests/snapshots/e2e__locked_mode_lockfile.snap
+++ b/tests/snapshots/e2e__locked_mode_lockfile.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: "result.lockfile_snapshot(&[&repo1])"
+expression: result.snapshot_lockfile()
 ---
 version = 2
 

--- a/tests/snapshots/e2e__locked_mode_output.snap
+++ b/tests/snapshots/e2e__locked_mode_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === proto/v1.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__partial_update_lockfile.snap
+++ b/tests/snapshots/e2e__partial_update_lockfile.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: "result.lockfile_snapshot(&[&repo1, &repo2])"
+expression: result.snapshot_lockfile()
 ---
 version = 2
 

--- a/tests/snapshots/e2e__partial_update_output.snap
+++ b/tests/snapshots/e2e__partial_update_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === proto/b.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__prune_output.snap
+++ b/tests/snapshots/e2e__prune_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === imported.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__regex_policy_output.snap
+++ b/tests/snapshots/e2e__regex_policy_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === service.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__revision_pin_lockfile.snap
+++ b/tests/snapshots/e2e__revision_pin_lockfile.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: "result.lockfile_snapshot(&[&repo1])"
+expression: result.snapshot_lockfile()
 ---
 version = 2
 

--- a/tests/snapshots/e2e__revision_pin_output.snap
+++ b/tests/snapshots/e2e__revision_pin_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === proto/v1.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__single_file_dep_lockfile.snap
+++ b/tests/snapshots/e2e__single_file_dep_lockfile.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: "result.lockfile_snapshot(&[&repo])"
+expression: result.snapshot_lockfile()
 ---
 version = 2
 

--- a/tests/snapshots/e2e__single_file_dep_output.snap
+++ b/tests/snapshots/e2e__single_file_dep_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === proto/hello.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__transitive_flag_lockfile.snap
+++ b/tests/snapshots/e2e__transitive_flag_lockfile.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: "result.lockfile_snapshot(&[&repo_shared, &repo_a])"
+expression: result.snapshot_lockfile()
 ---
 version = 2
 

--- a/tests/snapshots/e2e__transitive_flag_output.snap
+++ b/tests/snapshots/e2e__transitive_flag_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === a.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__transitive_only_lockfile.snap
+++ b/tests/snapshots/e2e__transitive_only_lockfile.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: "result.lockfile_snapshot(&[&repo1, &repo2])"
+expression: result.snapshot_lockfile()
 ---
 version = 2
 

--- a/tests/snapshots/e2e__transitive_only_output.snap
+++ b/tests/snapshots/e2e__transitive_only_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === proto/a.proto ===
 syntax = "proto3";

--- a/tests/snapshots/e2e__two_repos_lockfile.snap
+++ b/tests/snapshots/e2e__two_repos_lockfile.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: "result.lockfile_snapshot(&[&repo1, &repo2])"
+expression: result.snapshot_lockfile()
 ---
 version = 2
 

--- a/tests/snapshots/e2e__two_repos_output.snap
+++ b/tests/snapshots/e2e__two_repos_output.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/e2e.rs
-expression: snapshot_tree(&result.output_dir)
+expression: result.snapshot_tree()
 ---
 === proto/b.proto ===
 syntax = "proto3";


### PR DESCRIPTION
In https://github.com/coralogix/protofetch/pull/210 we started taking into account allow/deny policies from all occurrences of a module in the dependency tree, not only from the first one. However, this didn't apply for content roots, they we just merged into a single list. This meant that a policy might be evaluated against a path that is relative to a content root from a different dependency occurrence. Now protofetch will evaluate policies and content roots together.

This, however, brings a new challenge — the same proto file can end up under multiple different paths, if it is included relatively to different content roots. This is probably undesired, as duplicate protos may for example break code generation. Therefore, we will now apply deduplication logic similar to what we do with dependency versions — a path introduced by a dependency closer to the root module wins.