### PR TITLE
Documentation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,37 @@ This can be changed, but it is heavily discouraged.
 | protocol       | String   | Optional  | A protocol to use: [ssh, https]                                                    | `ssh`                                                   |
 | allow_policies | [String] | Optional  | Allow policy rules (`*` at the beginning or end matches arbitrary directory depth) | `"/prefix/*"`, `"*/subpath/*"`, `"/path/to/file.proto"` |
 | deny_policies  | [String] | Optional  | Deny policy rules (`*` at the beginning or end matches arbitrary directory depth)  | `"/prefix/*"`, `"*/subpath/*"`, `"/path/to/file.proto"` |
-| prune          | bool     | Optional  | Whether to prune unneeded transitive proto files                                   | `true` / `false`                                        |
+| prune          | bool     | Optional  | Whether to follow proto imports instead of copying by module dependency alone      | `true` / `false`                                        |
 | transitive     | bool     | Optional  | Flags this dependency as transitive                                                | `true` / `false`                                        |
 | content_roots  | [String] | Optional  | Which subdirectories to import from                                                | `["/myservice", "/com/org/client"]`                     |
+
+### Allow and deny policies
 
 The patterns in `allow_policies` and `deny_policies` are matched against the paths relative to the nearest path in `content_roots`.
 
 `allow_policies` apply only to the dependency they are defined on and describe the proto files you want from that dependency.
-When `prune = false`, only matching proto files are included. When `prune = true`, matching proto files and their import tree are included.
+When `prune = false`, only matching proto files are included.
+When `prune = true`, matching proto files are used as traversal roots: protofetch follows their proto `import` statements across module dependencies, may include additional imported files from the same module, and may include imported files from the dependency subtree.
 
 `deny_policies` apply to the whole dependency subtree.
-When `prune = false`, matching proto files are excluded. When `prune = true`, matching proto files and their dependencies are excluded.
+When `prune = false`, matching proto files are excluded.
+When `prune = true`, matching proto files and their import tree are excluded.
+
+### Dependency pruning
+
+The pruning feature makes protofetch follow proto file
+`import` statements instead of copying files only from module-level dependency relationships. With pruning enabled,
+protofetch starts from the files included by `allow_policies`, recursively follows their imports across module dependencies,
+and fetches every imported proto file it reaches. This traversal may include additional files from the same module even if
+they were not directly matched by `allow_policies`, and it may include imported proto files from the dependency subtree.
+
+### Additional transitive dependencies
+
+When pruning is enabled, protofetch looks for imported proto files in the module dependency tree.
+This relies on each dependency declaring its own module dependencies in a `protofetch.toml` file. If a dependency does
+not provide one, you can still use the pruning feature by declaring additional dependencies with `transitive = true`.
+Files from transitive dependencies are not fetched directly. They are available as candidates and are copied only if the
+`import` traversal from a pruned dependency reaches them.
 
 ### Protofetch dependency toml example
 
@@ -112,7 +132,6 @@ description = "this is a repository"
 
 [dep1]
 url = "github.com/org/dep1"
-protocol = "https"
 revision = "1.3.0"
 prune = true
 allow_policies = ["/prefix/*", "*/subpath/*", "/path/to/file.proto"]
@@ -176,43 +195,4 @@ url = "github.com/org/dep4"
 revision = "v1.1"
 content_roots = ["/scope"]
 allow_policies = ["path1/*"]
-```
-
-
-## Transitive dependency support and pruning
-
-Protofetch supports pulling transitive dependencies for your convenience.
-However, there is some manual work involved if the dependencies do not define their own protofetch module.
-
-In a situation where A depends on B, you should flag that dependency as transitive.
-
-This is helpful especially when you take advantage of the pruning feature which allows you to only recursively fetch
-the proto files you actually need. With pruning enabled, protofetch will recursively find what protofiles your root
-protos depend on and fetch them for as long as they are imported (flag as transitive dependency or fetched from other modules).
-
-Moreover, you can also use the allow_policies to scope down the root proto files you want from a dependency.
-As an example, the following module depends only on A's file `/proto/path/example.proto` but since pruning is enabled and
-B is flagged as transitive, if the allowed file has any file dependencies it will pull them and its dependencies, recursively.
-
-IMPORTANT: If you are using the `prune` feature, you must also use the `transitive` feature. However, do not use transitive
-unless you strictly want to pull the transitive dependencies. This is a workaround for dependencies that do not define
-their protofetch file on their repo.
-
-```toml
-name = "repository name"
-description = "this is a repository"
-proto_out_dir = "proto/src/dir/output"
-
-[A]
-protocol = "https"
-url = "github.com/org/A"
-revision = "1.3.0"
-allow_policies = ["/proto/path/example.proto"]
-prune = true
-
-[B]
-protocol = "ssh"
-url = "github.com/org/B"
-revision = "5.2.0"
-transitive = true
 ```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ This can be changed, but it is heavily discouraged.
 
 The patterns in `allow_policies` and `deny_policies` are matched against the paths relative to the nearest path in `content_roots`.
 
+`allow_policies` apply only to the dependency they are defined on and describe the proto files you want from that dependency.
+When `prune = false`, only matching proto files are included. When `prune = true`, matching proto files and their import tree are included.
+
+`deny_policies` apply to the whole dependency subtree.
+When `prune = false`, matching proto files are excluded. When `prune = true`, matching proto files and their dependencies are excluded.
+
 ### Protofetch dependency toml example
 
 ```toml

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -294,7 +294,8 @@ fn fetch_allow_policies_apply_only_to_own_dependency() {
 }
 
 /// With prune enabled, allow_policies select the root protos from the dependency,
-/// then protofetch includes those protos and their import tree.
+/// then protofetch includes those protos and their import tree, including files
+/// outside the allow_policies and files from the dependency subtree.
 #[test]
 fn fetch_allow_policies_with_prune_include_import_tree() {
     let mut world = TestWorld::new();
@@ -337,8 +338,16 @@ fn fetch_allow_policies_with_prune_include_import_tree() {
                 "public/service.proto",
                 indoc! {r#"
                     syntax = "proto3";
+                    import "internal/common.proto";
                     import "shared.proto";
                     message Service {}
+                "#},
+            ),
+            (
+                "internal/common.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Common {}
                 "#},
             ),
             (
@@ -611,21 +620,31 @@ fn fetch_revision_pin() {
 /// it in their own `protofetch.toml`.
 ///
 /// repo_a uses `prune = true` and its `a.proto` imports `shared.proto` from
-/// repo_shared.  repo_a has no `protofetch.toml`, so without `transitive = true`
-/// on repo_shared the import could not be resolved.
+/// repo_shared. repo_a has no `protofetch.toml`, so without `transitive = true`
+/// on repo_shared the import could not be resolved. Unimported files from
+/// repo_shared are not fetched directly.
 #[test]
 fn fetch_transitive_flag() {
     let mut world = TestWorld::new();
 
     world.create_repo(
         "org/repo_shared",
-        &[(
-            "shared.proto",
-            indoc! {r#"
-                syntax = "proto3";
-                message Shared {}
-            "#},
-        )],
+        &[
+            (
+                "shared.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Shared {}
+                "#},
+            ),
+            (
+                "unused.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Unused {}
+                "#},
+            ),
+        ],
     );
 
     world.create_repo(

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -220,16 +220,47 @@ fn fetch_locked_mode_uses_pinned_commit() {
     assert_snapshot!("locked_mode_lockfile", result.snapshot_lockfile());
 }
 
-/// Only files under directories matching allow_policies are copied.
-/// `allow_policies = ["public/*"]` is a Prefix policy: includes everything
-/// under `public/` and excludes everything else.
+/// allow_policies apply only to the dependency they are defined on.
+/// With prune disabled, matching files from that dependency are included and
+/// non-matching files are excluded, while transitive dependencies keep their own rules.
 #[test]
-fn fetch_allow_policies() {
+fn fetch_allow_policies_apply_only_to_own_dependency() {
     let mut world = TestWorld::new();
 
     world.create_repo(
-        "org/repo1",
+        "org/dep_child",
         &[
+            (
+                "public/child.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message ChildPublic {}
+                "#},
+            ),
+            (
+                "internal/child.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message ChildInternal {}
+                "#},
+            ),
+        ],
+    );
+
+    world.create_repo(
+        "org/dep_parent",
+        &[
+            (
+                "protofetch.toml",
+                indoc! {r#"
+                    name = "dep_parent"
+
+                    [dep_child]
+                    url = "<base>/org/dep_child"
+                    protocol = "file"
+                    branch = "main"
+                "#},
+            ),
             (
                 "public/service.proto",
                 indoc! {r#"
@@ -250,14 +281,90 @@ fn fetch_allow_policies() {
     let result = world.fetch(toml! {
         name = "e2e-test"
 
-        [repo1]
-        url = "org/repo1"
+        [dep_parent]
+        url = "org/dep_parent"
         branch = "main"
         allow_policies = ["public/*"]
     });
 
-    // Only public/service.proto; internal/admin.proto is excluded
-    assert_snapshot!("allow_policies_output", result.snapshot_tree());
+    assert_snapshot!(
+        "allow_policies_apply_only_to_own_dependency_output",
+        result.snapshot_tree()
+    );
+}
+
+/// With prune enabled, allow_policies select the root protos from the dependency,
+/// then protofetch includes those protos and their import tree.
+#[test]
+fn fetch_allow_policies_with_prune_include_import_tree() {
+    let mut world = TestWorld::new();
+
+    world.create_repo(
+        "org/dep_child",
+        &[
+            (
+                "shared.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Shared {}
+                "#},
+            ),
+            (
+                "unused.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Unused {}
+                "#},
+            ),
+        ],
+    );
+
+    world.create_repo(
+        "org/dep_parent",
+        &[
+            (
+                "protofetch.toml",
+                indoc! {r#"
+                    name = "dep_parent"
+
+                    [dep_child]
+                    url = "<base>/org/dep_child"
+                    protocol = "file"
+                    branch = "main"
+                "#},
+            ),
+            (
+                "public/service.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    import "shared.proto";
+                    message Service {}
+                "#},
+            ),
+            (
+                "internal/admin.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message Admin {}
+                "#},
+            ),
+        ],
+    );
+
+    let result = world.fetch(toml! {
+        name = "e2e-test"
+
+        [dep_parent]
+        url = "org/dep_parent"
+        branch = "main"
+        allow_policies = ["public/*"]
+        prune = true
+    });
+
+    assert_snapshot!(
+        "allow_policies_with_prune_include_import_tree_output",
+        result.snapshot_tree()
+    );
 }
 
 /// With content_roots = ["api/proto"] files under api/proto/ appear without
@@ -307,15 +414,48 @@ fn fetch_content_roots() {
     assert_snapshot!("content_roots_output", result.snapshot_tree());
 }
 
-/// deny_policies is the mirror of allow_policies: matching files are excluded.
-/// `deny_policies = ["internal/*"]` removes everything under internal/.
+/// deny_policies apply to the dependency subtree.
+/// With prune disabled, matching protos from the dependency and its transitive
+/// dependencies are excluded.
 #[test]
-fn fetch_deny_policies() {
+#[ignore = "documented behavior is not implemented for transitive dependency subtrees yet"]
+fn fetch_deny_policies_apply_to_dependency_subtree() {
     let mut world = TestWorld::new();
 
     world.create_repo(
-        "org/repo1",
+        "org/dep_child",
         &[
+            (
+                "public/child.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message ChildPublic {}
+                "#},
+            ),
+            (
+                "internal/child.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    message ChildInternal {}
+                "#},
+            ),
+        ],
+    );
+
+    world.create_repo(
+        "org/dep_parent",
+        &[
+            (
+                "protofetch.toml",
+                indoc! {r#"
+                    name = "dep_parent"
+
+                    [dep_child]
+                    url = "<base>/org/dep_child"
+                    protocol = "file"
+                    branch = "main"
+                "#},
+            ),
             (
                 "public/service.proto",
                 indoc! {r#"
@@ -336,64 +476,73 @@ fn fetch_deny_policies() {
     let result = world.fetch(toml! {
         name = "e2e-test"
 
-        [repo1]
-        url = "org/repo1"
+        [dep_parent]
+        url = "org/dep_parent"
         branch = "main"
         deny_policies = ["internal/*"]
     });
 
-    // internal/admin.proto excluded; public/service.proto kept
-    assert_snapshot!("deny_policies_output", result.snapshot_tree());
+    assert_snapshot!(
+        "deny_policies_apply_to_dependency_subtree_output",
+        result.snapshot_tree()
+    );
 }
 
-/// prune = true walks the import graph starting from the dep's own files and
-/// only includes transitive-dep files that are actually imported.  extra.proto
-/// in repo1 is never imported so it must be absent from the output.
+/// With prune enabled, deny_policies exclude matching protos and their dependencies.
 #[test]
-fn fetch_prune() {
+#[ignore = "documented behavior is not implemented for pruned deny import trees yet"]
+fn fetch_deny_policies_with_prune_exclude_matching_files_and_deps() {
     let mut world = TestWorld::new();
 
-    // repo1: two files; only imported.proto is imported by repo2
     world.create_repo(
-        "org/repo1",
+        "org/dep_child",
         &[
             (
-                "imported.proto",
+                "shared/secret.proto",
                 indoc! {r#"
                     syntax = "proto3";
-                    message Imported {}
+                    message Secret {}
                 "#},
             ),
             (
-                "extra.proto",
+                "shared/public.proto",
                 indoc! {r#"
                     syntax = "proto3";
-                    message Extra {}
+                    message Public {}
                 "#},
             ),
         ],
     );
 
     world.create_repo(
-        "org/repo2",
+        "org/dep_parent",
         &[
             (
                 "protofetch.toml",
                 indoc! {r#"
-                    name = "repo2"
+                    name = "dep_parent"
 
-                    [repo1]
-                    url = "<base>/org/repo1"
+                    [dep_child]
+                    url = "<base>/org/dep_child"
                     protocol = "file"
                     branch = "main"
                 "#},
             ),
             (
-                "service.proto",
+                "public/service.proto",
                 indoc! {r#"
                     syntax = "proto3";
-                    import "imported.proto";
+                    import "internal/admin.proto";
+                    import "shared/public.proto";
                     message Service {}
+                "#},
+            ),
+            (
+                "internal/admin.proto",
+                indoc! {r#"
+                    syntax = "proto3";
+                    import "shared/secret.proto";
+                    message Admin {}
                 "#},
             ),
         ],
@@ -402,14 +551,17 @@ fn fetch_prune() {
     let result = world.fetch(toml! {
         name = "e2e-test"
 
-        [repo2]
-        url = "org/repo2"
+        [dep_parent]
+        url = "org/dep_parent"
         branch = "main"
+        deny_policies = ["internal/*"]
         prune = true
     });
 
-    // service.proto + imported.proto are in the import chain; extra.proto is not
-    assert_snapshot!("prune_output", result.snapshot_tree());
+    assert_snapshot!(
+        "deny_policies_with_prune_exclude_matching_files_and_deps_output",
+        result.snapshot_tree()
+    );
 }
 
 /// `revision = "<hash>"` in the manifest pins to that exact commit.

--- a/tests/snapshots/e2e__allow_policies_apply_only_to_own_dependency_output.snap
+++ b/tests/snapshots/e2e__allow_policies_apply_only_to_own_dependency_output.snap
@@ -1,0 +1,15 @@
+---
+source: tests/e2e.rs
+expression: result.snapshot_tree()
+---
+=== internal/child.proto ===
+syntax = "proto3";
+message ChildInternal {}
+
+=== public/child.proto ===
+syntax = "proto3";
+message ChildPublic {}
+
+=== public/service.proto ===
+syntax = "proto3";
+message Service {}

--- a/tests/snapshots/e2e__allow_policies_with_prune_include_import_tree_output.snap
+++ b/tests/snapshots/e2e__allow_policies_with_prune_include_import_tree_output.snap
@@ -4,4 +4,9 @@ expression: result.snapshot_tree()
 ---
 === public/service.proto ===
 syntax = "proto3";
+import "shared.proto";
 message Service {}
+
+=== shared.proto ===
+syntax = "proto3";
+message Shared {}

--- a/tests/snapshots/e2e__allow_policies_with_prune_include_import_tree_output.snap
+++ b/tests/snapshots/e2e__allow_policies_with_prune_include_import_tree_output.snap
@@ -2,8 +2,13 @@
 source: tests/e2e.rs
 expression: result.snapshot_tree()
 ---
+=== internal/common.proto ===
+syntax = "proto3";
+message Common {}
+
 === public/service.proto ===
 syntax = "proto3";
+import "internal/common.proto";
 import "shared.proto";
 message Service {}
 

--- a/tests/snapshots/e2e__deny_policies_apply_to_dependency_subtree_output.snap
+++ b/tests/snapshots/e2e__deny_policies_apply_to_dependency_subtree_output.snap
@@ -2,11 +2,10 @@
 source: tests/e2e.rs
 expression: result.snapshot_tree()
 ---
-=== imported.proto ===
+=== public/child.proto ===
 syntax = "proto3";
-message Imported {}
+message ChildPublic {}
 
-=== service.proto ===
+=== public/service.proto ===
 syntax = "proto3";
-import "imported.proto";
 message Service {}

--- a/tests/snapshots/e2e__deny_policies_with_prune_exclude_matching_files_and_deps_output.snap
+++ b/tests/snapshots/e2e__deny_policies_with_prune_exclude_matching_files_and_deps_output.snap
@@ -4,4 +4,10 @@ expression: result.snapshot_tree()
 ---
 === public/service.proto ===
 syntax = "proto3";
+import "internal/admin.proto";
+import "shared/public.proto";
 message Service {}
+
+=== shared/public.proto ===
+syntax = "proto3";
+message Public {}


### PR DESCRIPTION
Improve `allow_policies`, `deny_policies`, `prune` and `transitive` documentation.

The important part is the `deny_policies`. Originally, the behavior was different for pruned and non-pruned dependencies. For pruned dependencies deny policies used to apply to the whole subtree. For non-pruned ones, they only applied to the dependency itself.

At some point we broke the pruned dependencies case. This made the behavior consistent, but much less useful: there was no way to get rid of unwanted proto files from transitive dependencies.

This PR does the opposite — it keeps the behavior consistent, but now the deny policies apply to the whole dependency subtree, regardless of whether pruning is enabled or not. We don't change the logic yet, only add the documentation and failing tests capturing the desired behavior.

While this is to some extent a breaking change, but at least according to github search there is only a handful of `deny_policies` usages and none of the public ones is going to be affected. It is also easily fixable — even if your dependency started excluding more files than necessary because of the changed logic, you can always add an explicit dependency fetching the missing ones. 