### PR TITLE
Use rayon for proto copy parallelism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +290,12 @@ dependencies = [
  "signature",
  "spki",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -984,6 +1015,7 @@ dependencies = [
  "log",
  "pretty_assertions",
  "project-root",
+ "rayon",
  "regex-lite",
  "serde",
  "ssh-key",
@@ -1040,6 +1072,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ git2 = ">=0.18.0, <0.21.0"
 # Upgrading home to 0.5.11 will bring MSRV to 1.81.0
 home = "0.5.9"
 log = "0.4.27"
+rayon = "1.10.0"
 regex-lite = "0.1.6"
 serde = { version = "1.0.219", features = ["derive"] }
 ssh-key = "0.6.7"

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -3,11 +3,11 @@ use std::{
     fs::File,
     io::{BufRead, BufReader},
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
-    thread,
+    sync::Arc,
 };
 
 use log::{debug, info, trace, warn};
+use rayon::{prelude::*, ThreadPoolBuildError, ThreadPoolBuilder};
 use thiserror::Error;
 
 use crate::{
@@ -27,6 +27,8 @@ pub enum ProtoError {
     IO(#[from] std::io::Error),
     #[error(transparent)]
     Cache(anyhow::Error),
+    #[error(transparent)]
+    ThreadPool(#[from] ThreadPoolBuildError),
 }
 
 /// Represents a mapping for a proto file between the source repo directory and the desired target.
@@ -108,38 +110,13 @@ where
 
     planned.sort_by_key(|copy| (copy.dep_order, copy.mapping.rule_order));
     let planned = dedupe_proto_copies(planned);
-    let copy_jobs = parallel.copy_jobs.max(1).min(planned.len());
-    let planned = Mutex::new(planned);
-
-    thread::scope(|s| -> Result<(), ProtoError> {
-        let mut handles = Vec::with_capacity(copy_jobs);
-        for _ in 0..copy_jobs {
-            let proto_dir = &proto_dir;
-            let planned = &planned;
-            handles.push(s.spawn(move || {
-                loop {
-                    let copy = planned.lock().expect("copy queue poisoned").pop();
-                    let Some(copy) = copy else {
-                        break;
-                    };
-                    copy_proto_source_for_dep(
-                        proto_dir,
-                        &copy.dep_cache_dir,
-                        &copy.dep,
-                        &copy.mapping,
-                    )?;
-                }
-                Ok::<_, ProtoError>(())
-            }));
-        }
-
-        for h in handles {
-            match h.join() {
-                Ok(result) => result?,
-                Err(payload) => std::panic::resume_unwind(payload),
-            }
-        }
-        Ok(())
+    let pool = ThreadPoolBuilder::new()
+        .num_threads(parallel.copy_jobs.max(1))
+        .build()?;
+    pool.install(|| {
+        planned.into_par_iter().try_for_each(|copy| {
+            copy_proto_source_for_dep(&proto_dir, &copy.dep_cache_dir, &copy.dep, &copy.mapping)
+        })
     })?;
 
     Ok(())


### PR DESCRIPTION
Separate parallelization machinery from the business logic, and use `rayon` for the implementation. This aligns with https://github.com/coralogix/protofetch/pull/223 using `rayon` too.