### PR TITLE
chore: release v0.1.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19](https://github.com/coralogix/protofetch/compare/v0.1.18...v0.1.19) - 2026-06-19
+
+### Other
+
+- Rewrite proto copying ([#226](https://github.com/coralogix/protofetch/pull/226))
+- Use rayon for dependency fetches ([#225](https://github.com/coralogix/protofetch/pull/225))
+- Fully remove the old resolve implementation ([#224](https://github.com/coralogix/protofetch/pull/224))
+- Rewrite module resolution ([#223](https://github.com/coralogix/protofetch/pull/223))
+- Use rayon for proto copy parallelism ([#222](https://github.com/coralogix/protofetch/pull/222))
+- Make it explicit that we copy single proto source at a time ([#221](https://github.com/coralogix/protofetch/pull/221))
+- Extract e2e test fixtures into files ([#220](https://github.com/coralogix/protofetch/pull/220))
+- Documentation and tests ([#219](https://github.com/coralogix/protofetch/pull/219))
+- Content root fixes ([#218](https://github.com/coralogix/protofetch/pull/218))
+
 ## [0.1.18](https://github.com/coralogix/protofetch/compare/v0.1.17...v0.1.18) - 2026-06-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `protofetch`: 0.1.18 -> 0.1.19

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.19](https://github.com/coralogix/protofetch/compare/v0.1.18...v0.1.19) - 2026-06-19

### Other

- Rewrite proto copying ([#226](https://github.com/coralogix/protofetch/pull/226))
- Use rayon for dependency fetches ([#225](https://github.com/coralogix/protofetch/pull/225))
- Fully remove the old resolve implementation ([#224](https://github.com/coralogix/protofetch/pull/224))
- Rewrite module resolution ([#223](https://github.com/coralogix/protofetch/pull/223))
- Use rayon for proto copy parallelism ([#222](https://github.com/coralogix/protofetch/pull/222))
- Make it explicit that we copy single proto source at a time ([#221](https://github.com/coralogix/protofetch/pull/221))
- Extract e2e test fixtures into files ([#220](https://github.com/coralogix/protofetch/pull/220))
- Documentation and tests ([#219](https://github.com/coralogix/protofetch/pull/219))
- Content root fixes ([#218](https://github.com/coralogix/protofetch/pull/218))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).