### PR TITLE
chore: strip release binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ pretty_assertions = "1.4.1"
 project-root = "0.2.2"
 tempfile = "3.10"
 
+[profile.release]
+strip = true
+
 [profile.dev.package.insta]
 opt-level = 3
 


### PR DESCRIPTION
The difference is small (4.22 MB -> 3.71 MB for the biggest one), but I suppose there are no disadvantages either.

Closes #35