### PR TITLE
feat: support targeted lock updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ protofetch fetch
 
 # Verify the lock file, and fetch proto sources. Useful for CI.
 protofetch fetch --locked
+
+# Update all locked dependencies.
+protofetch update
+
+# Update only selected dependencies.
+protofetch update module-a module-b
+
+# Update one dependency to an exact commit.
+protofetch update module-a --precise abc123
 ```
 
 ## Protofetch module

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -39,6 +39,34 @@ pub enum LockMode {
     Recreate,
 }
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum LockUpdateMode {
+    /// Verify that the lock file is up to date.
+    Verify,
+    /// Reconcile the lock file with the current module descriptor, updating it if necessary.
+    Reconcile,
+    /// Reconcile the lock file and update the selected dependencies, keeping other locked entries pinned.
+    ReconcileAndUpdate(Vec<DependencyUpdate>),
+    /// Recreate the lock file from scratch, updating all dependencies.
+    Full,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum DependencyUpdate {
+    Latest { name: String },
+    Precise { name: String, commit_hash: String },
+}
+
+impl From<LockMode> for LockUpdateMode {
+    fn from(lock_mode: LockMode) -> Self {
+        match lock_mode {
+            LockMode::Locked => LockUpdateMode::Verify,
+            LockMode::Update => LockUpdateMode::Reconcile,
+            LockMode::Recreate => LockUpdateMode::Full,
+        }
+    }
+}
+
 impl Protofetch {
     pub fn builder() -> ProtofetchBuilder {
         ProtofetchBuilder::default()
@@ -62,10 +90,16 @@ impl Protofetch {
         )
     }
 
-    /// Creates, updates or verifies a lock file based on the toml configuration file
+    /// Creates, updates or verifies a lock file based on the toml configuration file.
+    #[deprecated(note = "use Protofetch::update instead")]
     pub fn lock(&self, lock_mode: LockMode) -> Result<(), Box<dyn Error>> {
+        self.update(lock_mode.into())
+    }
+
+    /// Creates, updates or verifies a lock file based on the toml configuration file.
+    pub fn update(&self, lock_update_mode: LockUpdateMode) -> Result<(), Box<dyn Error>> {
         do_lock(
-            lock_mode,
+            lock_update_mode,
             self.cache.clone(),
             &self.root,
             &self.module_file_name,

--- a/src/cli/command_handlers.rs
+++ b/src/cli/command_handlers.rs
@@ -1,7 +1,7 @@
 use log::{debug, info};
 
 use crate::{
-    api::LockMode,
+    api::{DependencyUpdate, LockMode, LockUpdateMode},
     engine::{self, model::ResolvedRootModule, ParallelConfig},
     git::cache::ProtofetchGitCache,
     model::{
@@ -11,6 +11,7 @@ use crate::{
     resolver::{LockFileModuleResolver, ModuleResolver},
 };
 use std::{
+    collections::{BTreeMap, BTreeSet},
     error::Error,
     path::{Path, PathBuf},
     sync::Arc,
@@ -36,7 +37,7 @@ pub fn do_fetch(
     let proto_out = root.join(output_directory_name);
 
     let resolved = do_lock_inner(
-        lock_mode,
+        lock_mode.into(),
         cache.clone(),
         root,
         module_file_name,
@@ -65,7 +66,7 @@ pub fn do_fetch(
 /// Handler to lock command. Loads dependency descriptor from protofetch toml
 /// or protodep toml. Generates a lock file based on the protofetch.toml.
 pub fn do_lock(
-    lock_mode: LockMode,
+    lock_update_mode: LockUpdateMode,
     cache: Arc<ProtofetchGitCache>,
     root: &Path,
     module_file_name: &Path,
@@ -73,7 +74,7 @@ pub fn do_lock(
     parallel: ParallelConfig,
 ) -> Result<ResolvedRootModule, Box<dyn Error>> {
     do_lock_inner(
-        lock_mode,
+        lock_update_mode,
         cache,
         root,
         module_file_name,
@@ -83,7 +84,7 @@ pub fn do_lock(
 }
 
 fn do_lock_inner(
-    lock_mode: LockMode,
+    lock_update_mode: LockUpdateMode,
     cache: Arc<ProtofetchGitCache>,
     root: &Path,
     module_file_name: &Path,
@@ -93,71 +94,129 @@ fn do_lock_inner(
     let module_descriptor = load_module_descriptor(root, module_file_name)?;
     let lock_file_path = root.join(lock_file_name);
 
-    let (old_lock, (resolved, lockfile)) = match (lock_mode, lock_file_path.exists()) {
-        (LockMode::Locked, false) => return Err("Lock file does not exist".into()),
+    let (old_lock, (resolved, lockfile), selected_names) =
+        match (lock_update_mode, lock_file_path.exists()) {
+            (LockUpdateMode::Verify, false) => return Err("Lock file does not exist".into()),
 
-        (LockMode::Locked, true) => {
-            let old_lock = LockFile::from_file(&lock_file_path)?;
-            let resolver: Arc<dyn ModuleResolver> = Arc::new(LockFileModuleResolver::new(
-                cache.clone(),
-                old_lock.clone(),
-                true,
-            ));
-            debug!("Verifying lockfile...");
-            let resolved = engine::resolve(
-                &module_descriptor,
-                resolver,
-                cache.coord_locks().clone(),
-                parallel.network_jobs,
-            )?;
-            (Some(old_lock), resolved)
-        }
-
-        (LockMode::Update, false) => {
-            debug!("Generating lockfile...");
-            let resolver: Arc<dyn ModuleResolver> = cache.clone();
-            (
-                None,
-                engine::resolve(
+            (LockUpdateMode::Verify, true) => {
+                let old_lock = LockFile::from_file(&lock_file_path)?;
+                let resolver: Arc<dyn ModuleResolver> = Arc::new(LockFileModuleResolver::new(
+                    cache.clone(),
+                    old_lock.clone(),
+                    true,
+                ));
+                debug!("Verifying lockfile...");
+                let resolved = engine::resolve(
                     &module_descriptor,
                     resolver,
                     cache.coord_locks().clone(),
                     parallel.network_jobs,
-                )?,
-            )
-        }
+                )?;
+                (Some(old_lock), resolved, None)
+            }
 
-        (LockMode::Update, true) => {
-            let old_lock = LockFile::from_file(&lock_file_path)?;
-            let resolver: Arc<dyn ModuleResolver> = Arc::new(LockFileModuleResolver::new(
-                cache.clone(),
-                old_lock.clone(),
-                false,
-            ));
-            debug!("Updating lockfile...");
-            let resolved = engine::resolve(
-                &module_descriptor,
-                resolver,
-                cache.coord_locks().clone(),
-                parallel.network_jobs,
-            )?;
-            (Some(old_lock), resolved)
-        }
+            (LockUpdateMode::Reconcile, false) => {
+                debug!("Generating lockfile...");
+                let resolver: Arc<dyn ModuleResolver> = cache.clone();
+                (
+                    None,
+                    engine::resolve(
+                        &module_descriptor,
+                        resolver,
+                        cache.coord_locks().clone(),
+                        parallel.network_jobs,
+                    )?,
+                    None,
+                )
+            }
 
-        (LockMode::Recreate, _) => {
-            debug!("Generating lockfile...");
-            let resolver: Arc<dyn ModuleResolver> = cache.clone();
-            (
-                None,
-                engine::resolve(
+            (LockUpdateMode::Reconcile, true) => {
+                let old_lock = LockFile::from_file(&lock_file_path)?;
+                let resolver: Arc<dyn ModuleResolver> = Arc::new(LockFileModuleResolver::new(
+                    cache.clone(),
+                    old_lock.clone(),
+                    false,
+                ));
+                debug!("Updating lockfile...");
+                let resolved = engine::resolve(
                     &module_descriptor,
                     resolver,
                     cache.coord_locks().clone(),
                     parallel.network_jobs,
-                )?,
-            )
+                )?;
+                (Some(old_lock), resolved, None)
+            }
+
+            (LockUpdateMode::Full, _) => {
+                debug!("Generating lockfile...");
+                let resolver: Arc<dyn ModuleResolver> = cache.clone();
+                (
+                    None,
+                    engine::resolve(
+                        &module_descriptor,
+                        resolver,
+                        cache.coord_locks().clone(),
+                        parallel.network_jobs,
+                    )?,
+                    None,
+                )
+            }
+
+            (LockUpdateMode::ReconcileAndUpdate(updates), false) => {
+                debug!("Generating lockfile...");
+                let updates = dependency_updates(updates)?;
+                let selected_names = updates.keys().cloned().collect::<BTreeSet<_>>();
+                let resolver: Arc<dyn ModuleResolver> =
+                    Arc::new(LockFileModuleResolver::new_selected(
+                        cache.clone(),
+                        LockFile {
+                            dependencies: Vec::new(),
+                        },
+                        updates,
+                    ));
+                (
+                    None,
+                    engine::resolve(
+                        &module_descriptor,
+                        resolver,
+                        cache.coord_locks().clone(),
+                        parallel.network_jobs,
+                    )?,
+                    Some(selected_names),
+                )
+            }
+
+            (LockUpdateMode::ReconcileAndUpdate(updates), true) => {
+                let old_lock = LockFile::from_file(&lock_file_path)?;
+                let updates = dependency_updates(updates)?;
+                let selected_names = updates.keys().cloned().collect::<BTreeSet<_>>();
+                let resolver: Arc<dyn ModuleResolver> = Arc::new(
+                    LockFileModuleResolver::new_selected(cache.clone(), old_lock.clone(), updates),
+                );
+                debug!("Updating selected lockfile entries...");
+                let resolved = engine::resolve(
+                    &module_descriptor,
+                    resolver,
+                    cache.coord_locks().clone(),
+                    parallel.network_jobs,
+                )?;
+                (Some(old_lock), resolved, Some(selected_names))
+            }
+        };
+
+    if let Some(selected_names) = &selected_names {
+        let resolved_names = lockfile
+            .dependencies
+            .iter()
+            .map(|dependency| dependency.name.to_string())
+            .collect::<BTreeSet<_>>();
+        if let Some(name) = selected_names
+            .iter()
+            .find(|name| !resolved_names.contains(*name))
+        {
+            return Err(format!("No dependency named {name}").into());
         }
-    };
+    }
 
     debug!("Generated lockfile: {:?}", lockfile);
 
@@ -169,6 +228,25 @@ fn do_lock_inner(
     }
 
     Ok(resolved)
+}
+
+fn dependency_updates(
+    updates: Vec<DependencyUpdate>,
+) -> Result<BTreeMap<String, Option<String>>, Box<dyn Error>> {
+    let mut result = BTreeMap::new();
+    for update in updates {
+        let (name, precise) = match update {
+            DependencyUpdate::Latest { name } => (name, None),
+            DependencyUpdate::Precise {
+                name,
+                commit_hash: precise,
+            } => (name, Some(precise)),
+        };
+        if result.insert(name.clone(), precise).is_some() {
+            return Err(format!("Dependency {name} selected more than once").into());
+        }
+    }
+    Ok(result)
 }
 
 /// Handler to init command

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -27,6 +27,18 @@ pub enum ProtoRepoError {
     BranchNotFound { branch: String },
     #[error("Revision {revision} does not belong to the branch {branch}.")]
     RevisionNotOnBranch { revision: String, branch: String },
+    #[error("Precise commit {commit_hash} does not match revision {revision}")]
+    PreciseRevisionMismatch {
+        commit_hash: String,
+        revision: String,
+    },
+    #[error("Invalid commit hash {commit_hash}: {source}")]
+    InvalidCommitHash {
+        commit_hash: String,
+        source: git2::Error,
+    },
+    #[error("Commit {commit_hash} was not found")]
+    CommitNotFound { commit_hash: String },
     #[error("Worktree with name {name} already exists at {existing_path} but we need it at {wanted_path}")]
     WorktreeExists {
         name: String,
@@ -84,21 +96,62 @@ impl ProtoGitRepository<'_> {
         specification: &RevisionSpecification,
         commit_hash: &str,
     ) -> anyhow::Result<()> {
-        let oid = Oid::from_str(commit_hash)?;
-        if self.git_repo.find_commit(oid).is_ok() {
-            return Ok(());
-        }
-        let mut remote = self.git_repo.find_remote("origin")?;
+        let oid =
+            Oid::from_str(commit_hash).map_err(|source| ProtoRepoError::InvalidCommitHash {
+                commit_hash: commit_hash.to_owned(),
+                source,
+            })?;
+        if self.git_repo.find_commit(oid).is_err() {
+            let mut remote = self.git_repo.find_remote("origin")?;
 
-        debug!("Fetching {} from {}", commit_hash, self.origin);
-        if let Err(error) =
-            remote.fetch(&[commit_hash], Some(&mut self.cache.fetch_options()?), None)
+            debug!("Fetching {} from {}", commit_hash, self.origin);
+            if let Err(error) =
+                remote.fetch(&[commit_hash], Some(&mut self.cache.fetch_options()?), None)
+            {
+                warn!(
+                    "Failed to fetch a single commit {}, falling back to a full fetch: {}",
+                    commit_hash, error
+                );
+                self.fetch(specification)?;
+            }
+
+            self.git_repo
+                .find_commit(oid)
+                .map_err(|_| ProtoRepoError::CommitNotFound {
+                    commit_hash: commit_hash.to_owned(),
+                })?;
+        }
+
+        if specification.branch.is_some()
+            || matches!(specification.revision, Revision::Pinned { .. })
         {
-            warn!(
-                "Failed to fetch a single commit {}, falling back to a full fetch: {}",
-                commit_hash, error
-            );
             self.fetch(specification)?;
+        }
+
+        if let Some(branch) = &specification.branch {
+            let branch_commit = self
+                .commit_hash_for_obj_str(&format!("origin/{branch}"))
+                .map_err(|_| ProtoRepoError::BranchNotFound {
+                    branch: branch.to_owned(),
+                })?;
+            if !self.is_ancestor(oid, branch_commit)? {
+                return Err(ProtoRepoError::RevisionNotOnBranch {
+                    revision: commit_hash.to_owned(),
+                    branch: branch.to_owned(),
+                }
+                .into());
+            }
+        }
+
+        if let Revision::Pinned { revision } = &specification.revision {
+            let revision_commit = self.commit_hash_for_obj_str(revision)?;
+            if oid != revision_commit {
+                return Err(ProtoRepoError::PreciseRevisionMismatch {
+                    commit_hash: commit_hash.to_owned(),
+                    revision: revision.to_owned(),
+                }
+                .into());
+            }
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,4 @@ mod git;
 mod model;
 mod resolver;
 
-pub use api::{LockMode, Protofetch, ProtofetchBuilder};
+pub use api::{DependencyUpdate, LockMode, LockUpdateMode, Protofetch, ProtofetchBuilder};

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use env_logger::Target;
 
 use log::warn;
-use protofetch::{LockMode, Protofetch};
+use protofetch::{DependencyUpdate, LockMode, LockUpdateMode, Protofetch};
 
 /// Dependency management tool for Protocol Buffers files.
 #[derive(Debug, Parser)]
@@ -49,7 +49,14 @@ pub enum Command {
     /// Creates a lock file based on toml configuration file
     Lock,
     /// Updates the lock file
-    Update,
+    Update {
+        /// Dependencies to update
+        #[clap(value_name = "DEP")]
+        deps: Vec<String>,
+        /// Update the selected dependency to this exact commit
+        #[clap(long)]
+        precise: Option<String>,
+    },
     /// Creates an init protofetch setup in provided directory and name
     Init {
         #[clap(default_value = ".")]
@@ -140,8 +147,31 @@ fn run() -> Result<(), Box<dyn Error>> {
 
             protofetch.try_build()?.fetch(lock_mode)
         }
-        Command::Lock => protofetch.try_build()?.lock(LockMode::Update),
-        Command::Update => protofetch.try_build()?.lock(LockMode::Recreate),
+        Command::Lock => protofetch.try_build()?.update(LockUpdateMode::Reconcile),
+        Command::Update { deps, precise } => {
+            if precise.is_some() && deps.len() != 1 {
+                return Err("--precise requires exactly one DEP".into());
+            }
+
+            if deps.is_empty() {
+                protofetch.try_build()?.update(LockUpdateMode::Full)
+            } else {
+                let updates = match precise {
+                    Some(commit_hash) => vec![DependencyUpdate::Precise {
+                        name: deps.into_iter().next().expect("validated one DEP"),
+                        commit_hash,
+                    }],
+                    None => deps
+                        .into_iter()
+                        .map(|name| DependencyUpdate::Latest { name })
+                        .collect(),
+                };
+
+                protofetch
+                    .try_build()?
+                    .update(LockUpdateMode::ReconcileAndUpdate(updates))
+            }
+        }
         Command::Init { directory, name } => protofetch.root(directory).try_build()?.init(name),
         Command::Migrate { directory, name } => protofetch
             .root(&directory)
@@ -149,5 +179,46 @@ fn run() -> Result<(), Box<dyn Error>> {
             .migrate(name, directory),
         Command::Clean => protofetch.try_build()?.clean(),
         Command::ClearCache => protofetch.try_build()?.clear_cache(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::{CliArgs, Command};
+
+    #[test]
+    fn update_accepts_positional_specs_and_precise() {
+        let args =
+            CliArgs::try_parse_from(["protofetch", "update", "repo1", "--precise", "abc123"])
+                .unwrap();
+
+        match args.cmd {
+            Command::Update {
+                deps: specs,
+                precise,
+            } => {
+                assert_eq!(specs, vec!["repo1"]);
+                assert_eq!(precise.as_deref(), Some("abc123"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn update_accepts_multiple_positional_specs() {
+        let args = CliArgs::try_parse_from(["protofetch", "update", "repo1", "repo2"]).unwrap();
+
+        match args.cmd {
+            Command::Update {
+                deps: specs,
+                precise,
+            } => {
+                assert_eq!(specs, vec!["repo1", "repo2"]);
+                assert_eq!(precise, None);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
     }
 }

--- a/src/resolver/lock.rs
+++ b/src/resolver/lock.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use anyhow::bail;
 use log::debug;
 
@@ -12,6 +14,7 @@ pub struct LockFileModuleResolver<R> {
     inner: R,
     lock_file: LockFile,
     locked: bool,
+    updates: BTreeMap<String, Option<String>>,
 }
 
 impl<R> LockFileModuleResolver<R> {
@@ -20,6 +23,20 @@ impl<R> LockFileModuleResolver<R> {
             inner,
             lock_file,
             locked,
+            updates: BTreeMap::new(),
+        }
+    }
+
+    pub fn new_selected(
+        inner: R,
+        lock_file: LockFile,
+        updates: BTreeMap<String, Option<String>>,
+    ) -> Self {
+        Self {
+            inner,
+            lock_file,
+            locked: false,
+            updates,
         }
     }
 }
@@ -35,6 +52,16 @@ where
         commit_hash: Option<&str>,
         name: &ModuleName,
     ) -> anyhow::Result<CommitAndDescriptor> {
+        if let Some(precise) = self.updates.get(&name.to_string()) {
+            debug!("Dependency {} selected for update", name);
+            return self.inner.resolve(
+                coordinate,
+                specification,
+                precise.as_deref().or(commit_hash),
+                name,
+            );
+        }
+
         let locked_coordinate = LockedCoordinate::from(coordinate);
         let dependency = self.lock_file.dependencies.iter().find(|dependency| {
             dependency.coordinate == locked_coordinate && &dependency.specification == specification
@@ -78,5 +105,115 @@ where
                     .resolve(coordinate, specification, commit_hash, name)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::{
+        model::protofetch::{
+            lock::{LockFile, LockedCoordinate, LockedDependency},
+            Coordinate, Descriptor, ModuleName, RevisionSpecification,
+        },
+        resolver::{CommitAndDescriptor, LockFileModuleResolver, ModuleResolver},
+    };
+
+    struct FakeResolver;
+
+    impl ModuleResolver for FakeResolver {
+        fn resolve(
+            &self,
+            _: &Coordinate,
+            _: &RevisionSpecification,
+            commit_hash: Option<&str>,
+            name: &ModuleName,
+        ) -> anyhow::Result<CommitAndDescriptor> {
+            Ok(CommitAndDescriptor {
+                commit_hash: commit_hash.unwrap_or("fresh").to_owned(),
+                descriptor: Descriptor {
+                    name: name.clone(),
+                    description: None,
+                    proto_out_dir: None,
+                    dependencies: Vec::new(),
+                },
+            })
+        }
+    }
+
+    fn coordinate() -> Coordinate {
+        Coordinate::from_url("example.com/org/repo").unwrap()
+    }
+
+    fn lock_file() -> LockFile {
+        LockFile {
+            dependencies: vec![LockedDependency {
+                name: ModuleName::from("repo"),
+                coordinate: LockedCoordinate::from(&coordinate()),
+                specification: RevisionSpecification::default(),
+                commit_hash: "locked".to_owned(),
+            }],
+        }
+    }
+
+    #[test]
+    fn unselected_dependency_uses_lock_file() {
+        let resolver = LockFileModuleResolver::new_selected(
+            FakeResolver,
+            lock_file(),
+            BTreeMap::from([("other".to_owned(), None)]),
+        );
+
+        let resolved = resolver
+            .resolve(
+                &coordinate(),
+                &RevisionSpecification::default(),
+                None,
+                &ModuleName::from("repo"),
+            )
+            .unwrap();
+
+        assert_eq!(resolved.commit_hash, "locked");
+    }
+
+    #[test]
+    fn selected_dependency_bypasses_lock_file() {
+        let resolver = LockFileModuleResolver::new_selected(
+            FakeResolver,
+            lock_file(),
+            BTreeMap::from([("repo".to_owned(), None)]),
+        );
+
+        let resolved = resolver
+            .resolve(
+                &coordinate(),
+                &RevisionSpecification::default(),
+                None,
+                &ModuleName::from("repo"),
+            )
+            .unwrap();
+
+        assert_eq!(resolved.commit_hash, "fresh");
+    }
+
+    #[test]
+    fn selected_dependency_uses_precise_commit() {
+        let resolver = LockFileModuleResolver::new_selected(
+            FakeResolver,
+            lock_file(),
+            BTreeMap::from([("repo".to_owned(), Some("precise".to_owned()))]),
+        );
+
+        let resolved = resolver
+            .resolve(
+                &coordinate(),
+                &RevisionSpecification::default(),
+                None,
+                &ModuleName::from("repo"),
+            )
+            .unwrap();
+
+        assert_eq!(resolved.commit_hash, "precise");
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -2,7 +2,10 @@
 
 mod infra;
 
-use infra::{assert_output_contains, assert_output_excludes, run, run_locked};
+use infra::{
+    assert_output_contains, assert_output_excludes, run, run_locked, run_update_selected,
+    run_update_selected_error, FetchResult,
+};
 
 /// Fetch a single dependency with one proto file and assert the output tree.
 #[test]
@@ -218,6 +221,95 @@ fn partial_lock_update() {
 
     assert_output_contains(&result, &["proto/b.proto", "proto/v1.proto"]);
     assert_output_excludes(&result, &["proto/v2.proto"]);
+}
+
+#[test]
+fn selected_lock_update() {
+    let result = run_update_selected("selected_lock_update", "repo1", None);
+
+    assert_lockfile_dependency_commit(&result, "repo1", "<commit:main:2>");
+    assert_lockfile_dependency_commit(&result, "repo2", "<commit:main:3>");
+}
+
+#[test]
+fn selected_precise_lock_update() {
+    let result = run_update_selected(
+        "selected_precise_lock_update",
+        "repo1",
+        Some("<commit:main:2>"),
+    );
+
+    assert_lockfile_dependency_commit(&result, "repo1", "<commit:main:2>");
+    assert_lockfile_dependency_commit(&result, "repo2", "<commit:main:4>");
+}
+
+#[test]
+fn selected_precise_lock_update_rejects_invalid_commit_hash() {
+    let error = run_update_selected_error(
+        "selected_precise_revision_mismatch",
+        "repo1",
+        "not-a-commit",
+    );
+
+    assert!(
+        error.contains("Invalid commit hash not-a-commit"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn selected_precise_lock_update_rejects_missing_commit() {
+    let commit = "1111111111111111111111111111111111111111";
+    let error = run_update_selected_error("selected_precise_revision_mismatch", "repo1", commit);
+
+    assert!(
+        error.contains(&format!("Commit {commit} was not found")),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn selected_precise_lock_update_rejects_commit_from_another_branch() {
+    let error = run_update_selected_error(
+        "selected_precise_revision_mismatch",
+        "repo1",
+        "<commit:side:1>",
+    );
+
+    assert!(
+        error.contains("does not belong to the branch main"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn selected_precise_lock_update_rejects_revision_mismatch() {
+    let error = run_update_selected_error(
+        "selected_precise_revision_mismatch",
+        "repo1",
+        "<commit:main:2>",
+    );
+
+    assert!(
+        error.contains("does not match revision"),
+        "unexpected error: {error}"
+    );
+}
+
+fn assert_lockfile_dependency_commit(result: &FetchResult, name: &str, commit: &str) {
+    let snapshot = result.snapshot_lockfile();
+    let dependency = snapshot
+        .split("\n\n")
+        .find(|dependency| {
+            dependency.contains("[[dependencies]]")
+                && dependency.contains(&format!("name = \"{name}\""))
+        })
+        .unwrap_or_else(|| panic!("expected lockfile dependency {name}\n\n{snapshot}"));
+
+    assert!(
+        dependency.contains(&format!("commit_hash = \"{commit}\"")),
+        "expected {name} to be locked to {commit}\n\n{dependency}"
+    );
 }
 
 /// When the same dep is declared with `prune = true` in the root manifest but also

--- a/tests/e2e/selected_lock_update/protofetch.lock
+++ b/tests/e2e/selected_lock_update/protofetch.lock
@@ -1,0 +1,15 @@
+version = 2
+
+[[dependencies]]
+name = "repo1"
+url = "<base>/repo1"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:1>"
+
+[[dependencies]]
+name = "repo2"
+url = "<base>/repo2"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:3>"

--- a/tests/e2e/selected_lock_update/protofetch.toml
+++ b/tests/e2e/selected_lock_update/protofetch.toml
@@ -1,0 +1,9 @@
+name = "e2e-test"
+
+[repo1]
+url = "repo1"
+branch = "main"
+
+[repo2]
+url = "repo2"
+branch = "main"

--- a/tests/e2e/selected_lock_update/repo1/main/1/proto/v1.proto
+++ b/tests/e2e/selected_lock_update/repo1/main/1/proto/v1.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message V1 {}

--- a/tests/e2e/selected_lock_update/repo1/main/2/proto/v2.proto
+++ b/tests/e2e/selected_lock_update/repo1/main/2/proto/v2.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message V2 {}

--- a/tests/e2e/selected_lock_update/repo2/main/1/proto/b.proto
+++ b/tests/e2e/selected_lock_update/repo2/main/1/proto/b.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message B {}

--- a/tests/e2e/selected_lock_update/snapshots/lockfile.snap
+++ b/tests/e2e/selected_lock_update/snapshots/lockfile.snap
@@ -1,0 +1,18 @@
+---
+source: tests/infra/mod.rs
+---
+version = 2
+
+[[dependencies]]
+name = "repo1"
+url = "<base>/repo1"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:2>"
+
+[[dependencies]]
+name = "repo2"
+url = "<base>/repo2"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:3>"

--- a/tests/e2e/selected_precise_lock_update/protofetch.lock
+++ b/tests/e2e/selected_precise_lock_update/protofetch.lock
@@ -1,0 +1,15 @@
+version = 2
+
+[[dependencies]]
+name = "repo1"
+url = "<base>/repo1"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:1>"
+
+[[dependencies]]
+name = "repo2"
+url = "<base>/repo2"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:4>"

--- a/tests/e2e/selected_precise_lock_update/protofetch.toml
+++ b/tests/e2e/selected_precise_lock_update/protofetch.toml
@@ -1,0 +1,9 @@
+name = "e2e-test"
+
+[repo1]
+url = "repo1"
+branch = "main"
+
+[repo2]
+url = "repo2"
+branch = "main"

--- a/tests/e2e/selected_precise_lock_update/repo1/main/1/proto/v1.proto
+++ b/tests/e2e/selected_precise_lock_update/repo1/main/1/proto/v1.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message V1 {}

--- a/tests/e2e/selected_precise_lock_update/repo1/main/2/proto/v2.proto
+++ b/tests/e2e/selected_precise_lock_update/repo1/main/2/proto/v2.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message V2 {}

--- a/tests/e2e/selected_precise_lock_update/repo1/main/3/proto/v3.proto
+++ b/tests/e2e/selected_precise_lock_update/repo1/main/3/proto/v3.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message V3 {}

--- a/tests/e2e/selected_precise_lock_update/repo2/main/1/proto/b.proto
+++ b/tests/e2e/selected_precise_lock_update/repo2/main/1/proto/b.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message B {}

--- a/tests/e2e/selected_precise_lock_update/snapshots/lockfile.snap
+++ b/tests/e2e/selected_precise_lock_update/snapshots/lockfile.snap
@@ -1,0 +1,18 @@
+---
+source: tests/infra/mod.rs
+---
+version = 2
+
+[[dependencies]]
+name = "repo1"
+url = "<base>/repo1"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:2>"
+
+[[dependencies]]
+name = "repo2"
+url = "<base>/repo2"
+protocol = "file"
+branch = "main"
+commit_hash = "<commit:main:4>"

--- a/tests/e2e/selected_precise_revision_mismatch/protofetch.toml
+++ b/tests/e2e/selected_precise_revision_mismatch/protofetch.toml
@@ -1,0 +1,6 @@
+name = "e2e-test"
+
+[repo1]
+url = "repo1"
+branch = "main"
+revision = "<commit:main:1>"

--- a/tests/e2e/selected_precise_revision_mismatch/repo1/main/1/proto/v1.proto
+++ b/tests/e2e/selected_precise_revision_mismatch/repo1/main/1/proto/v1.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message V1 {}

--- a/tests/e2e/selected_precise_revision_mismatch/repo1/main/2/proto/v2.proto
+++ b/tests/e2e/selected_precise_revision_mismatch/repo1/main/2/proto/v2.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message V2 {}

--- a/tests/e2e/selected_precise_revision_mismatch/repo1/side/3/proto/side.proto
+++ b/tests/e2e/selected_precise_revision_mismatch/repo1/side/3/proto/side.proto
@@ -1,0 +1,2 @@
+syntax = "proto3";
+message Side {}

--- a/tests/infra/mod.rs
+++ b/tests/infra/mod.rs
@@ -4,13 +4,14 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    error::Error,
     fs,
     path::{Path, PathBuf},
 };
 
 use git2::{build::CheckoutBuilder, IndexAddOption, Repository, Signature};
 use insta::{assert_snapshot, Settings};
-use protofetch::{LockMode, Protofetch};
+use protofetch::{DependencyUpdate, LockMode, LockUpdateMode, Protofetch};
 use tempfile::TempDir;
 
 /// A local git repository created by [`TestWorld::create_repo`].
@@ -129,6 +130,52 @@ impl TestWorld {
         });
 
         result
+    }
+
+    fn run_update(name: &str, lock_update_mode: LockUpdateMode) -> FetchResult {
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/e2e")
+            .join(name);
+        let mut world = Self::new();
+        world.load_fixture_repos(&fixture);
+
+        let lock_update_mode =
+            resolve_lock_update_mode_labels(lock_update_mode, world.remotes.path(), &world.repos);
+
+        let manifest = fs::read_to_string(fixture.join("protofetch.toml"))
+            .expect("read fixture protofetch.toml");
+        let initial_lock = fs::read_to_string(fixture.join("protofetch.lock")).ok();
+        let result = world.update_files(&manifest, initial_lock.as_deref(), lock_update_mode);
+
+        let mut settings = Settings::clone_current();
+        settings.set_snapshot_path(fixture.join("snapshots"));
+        settings.set_prepend_module_to_snapshot(false);
+        settings.set_omit_expression(true);
+        settings.bind(|| {
+            assert_snapshot!("lockfile", result.snapshot_lockfile());
+        });
+
+        result
+    }
+
+    fn run_update_error(name: &str, lock_update_mode: LockUpdateMode) -> String {
+        let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/e2e")
+            .join(name);
+        let mut world = Self::new();
+        world.load_fixture_repos(&fixture);
+
+        let lock_update_mode =
+            resolve_lock_update_mode_labels(lock_update_mode, world.remotes.path(), &world.repos);
+
+        let manifest = fs::read_to_string(fixture.join("protofetch.toml"))
+            .expect("read fixture protofetch.toml");
+        let initial_lock = fs::read_to_string(fixture.join("protofetch.lock")).ok();
+
+        match world.update_files_result(&manifest, initial_lock.as_deref(), lock_update_mode) {
+            Ok(_) => panic!("protofetch update should fail"),
+            Err(error) => error.to_string(),
+        }
     }
 
     fn load_fixture_repos(&mut self, fixture: &Path) {
@@ -265,17 +312,62 @@ impl TestWorld {
         self.fetch_project(lock_mode)
     }
 
+    fn update_files(
+        &self,
+        manifest: &str,
+        initial_lock: Option<&str>,
+        lock_update_mode: LockUpdateMode,
+    ) -> FetchResult {
+        self.update_files_result(manifest, initial_lock, lock_update_mode)
+            .expect("protofetch update")
+    }
+
+    fn update_files_result(
+        &self,
+        manifest: &str,
+        initial_lock: Option<&str>,
+        lock_update_mode: LockUpdateMode,
+    ) -> Result<FetchResult, Box<dyn Error>> {
+        fs::write(
+            self.project.path().join("protofetch.toml"),
+            resolve_labels(
+                &prepare_manifest(manifest, self.remotes.path()),
+                self.remotes.path(),
+                &self.repos,
+            ),
+        )
+        .expect("write protofetch.toml");
+
+        if let Some(initial_lock) = initial_lock {
+            fs::write(
+                self.project.path().join("protofetch.lock"),
+                resolve_labels(initial_lock, self.remotes.path(), &self.repos),
+            )
+            .expect("write initial protofetch.lock");
+        }
+
+        self.protofetch().update(lock_update_mode)?;
+        Ok(self.snapshot_project())
+    }
+
     fn fetch_project(&self, lock_mode: LockMode) -> FetchResult {
-        let pf = Protofetch::builder()
+        let pf = self.protofetch();
+
+        pf.fetch(lock_mode).expect("protofetch fetch");
+        self.snapshot_project()
+    }
+
+    fn protofetch(&self) -> Protofetch {
+        Protofetch::builder()
             .root(self.project.path().to_path_buf())
             .cache_directory(self.cache.path().to_path_buf())
             .jobs(4)
             .copy_jobs(2)
             .try_build()
-            .expect("build Protofetch");
+            .expect("build Protofetch")
+    }
 
-        pf.fetch(lock_mode).expect("protofetch fetch");
-
+    fn snapshot_project(&self) -> FetchResult {
         let commits = self
             .repos
             .iter()
@@ -294,6 +386,28 @@ impl TestWorld {
 
 pub fn run(name: &str) -> FetchResult {
     TestWorld::run(name, LockMode::Update)
+}
+
+pub fn run_update_selected(name: &str, dep: &str, precise: Option<&str>) -> FetchResult {
+    TestWorld::run_update(name, selected_update_mode(dep, precise))
+}
+
+pub fn run_update_selected_error(name: &str, dep: &str, precise: &str) -> String {
+    TestWorld::run_update_error(name, selected_update_mode(dep, Some(precise)))
+}
+
+fn selected_update_mode(dep: &str, precise: Option<&str>) -> LockUpdateMode {
+    let updates = match precise {
+        Some(precise) => vec![DependencyUpdate::Precise {
+            name: dep.to_string(),
+            commit_hash: precise.to_string(),
+        }],
+        None => vec![DependencyUpdate::Latest {
+            name: dep.to_string(),
+        }],
+    };
+
+    LockUpdateMode::ReconcileAndUpdate(updates)
 }
 
 pub fn run_locked(name: &str) -> FetchResult {
@@ -395,6 +509,31 @@ fn resolve_labels(content: &str, remotes_path: &Path, repos: &[TestRepo]) -> Str
         }
     }
     result
+}
+
+fn resolve_lock_update_mode_labels(
+    lock_update_mode: LockUpdateMode,
+    remotes_path: &Path,
+    repos: &[TestRepo],
+) -> LockUpdateMode {
+    match lock_update_mode {
+        LockUpdateMode::ReconcileAndUpdate(updates) => LockUpdateMode::ReconcileAndUpdate(
+            updates
+                .into_iter()
+                .map(|update| match update {
+                    DependencyUpdate::Latest { name } => DependencyUpdate::Latest { name },
+                    DependencyUpdate::Precise {
+                        name,
+                        commit_hash: precise,
+                    } => DependencyUpdate::Precise {
+                        name,
+                        commit_hash: resolve_labels(&precise, remotes_path, repos),
+                    },
+                })
+                .collect(),
+        ),
+        lock_update_mode => lock_update_mode,
+    }
 }
 
 /// Returned by [`TestWorld::fetch`]; provides access to all fetch outputs.


### PR DESCRIPTION
Support
```
protofetch update module-a module-b
```
and
```
protofetch update module-a --precise commit
```

Closes #149.