### PR TITLE
chore: release v0.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20](https://github.com/coralogix/protofetch/compare/v0.1.19...v0.1.20) - 2026-07-14
+
+### Added
+
+- CLI backend in addition to libgit2 ([#191](https://github.com/coralogix/protofetch/pull/191))
+- support targeted lock updates ([#233](https://github.com/coralogix/protofetch/pull/233))
+
+### Other
+
+- update flake.lock ([#231](https://github.com/coralogix/protofetch/pull/231))
+- *(ci)* sign flake lock update commits ([#232](https://github.com/coralogix/protofetch/pull/232))
+- update flack.lock automatically ([#228](https://github.com/coralogix/protofetch/pull/228))
+- strip release binaries ([#230](https://github.com/coralogix/protofetch/pull/230))
+
 ## [0.1.19](https://github.com/coralogix/protofetch/compare/v0.1.18...v0.1.19) - 2026-06-19
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
 name = "protofetch"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "protofetch"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 rust-version = "1.75"
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `protofetch`: 0.1.19 -> 0.1.20

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.20](https://github.com/coralogix/protofetch/compare/v0.1.19...v0.1.20) - 2026-07-14

### Added

- CLI backend in addition to libgit2 ([#191](https://github.com/coralogix/protofetch/pull/191))
- support targeted lock updates ([#233](https://github.com/coralogix/protofetch/pull/233))

### Other

- update flake.lock ([#231](https://github.com/coralogix/protofetch/pull/231))
- *(ci)* sign flake lock update commits ([#232](https://github.com/coralogix/protofetch/pull/232))
- update flack.lock automatically ([#228](https://github.com/coralogix/protofetch/pull/228))
- strip release binaries ([#230](https://github.com/coralogix/protofetch/pull/230))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).