### PR TITLE
Restore using libgit2 backend by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,11 @@ name = "e2e"
 required-features = ["git-file-protocol"]
 
 [features]
-default = ["build-binary", "git-backend-libgit2", "git-backend-cli"]
+default = ["build-binary", "git-backend-cli"]
 build-binary = ["dep:clap", "dep:env_logger"]
-git-backend-libgit2 = ["dep:git2"]
 git-backend-cli = []
-vendored-openssl = ["git-backend-libgit2", "git2/vendored-openssl"]
-vendored-libgit2 = ["git-backend-libgit2", "git2/vendored-libgit2"]
+vendored-openssl = ["git2/vendored-openssl"]
+vendored-libgit2 = ["git2/vendored-libgit2"]
 
 # Support `protocol = "file"` in `protofetch.toml` for local dependencies.
 # This is useful for testing and development, but not intended for production use.
@@ -39,7 +38,7 @@ env_logger = { version = "0.11.8", default-features = false, features = [
 	"auto-color",
 ], optional = true }
 fs4 = "0.13.1"
-git2 = { version = ">=0.18.0, <0.21.0", optional = true }
+git2 = { version = ">=0.18.0, <0.21.0" }
 # Upgrading home to 0.5.11 will bring MSRV to 1.81.0
 home = "0.5.9"
 log = "0.4.27"

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,10 +29,7 @@ impl ProtofetchConfig {
             default_protocol: resolve_default_protocol(raw_config.git.protocol)?,
             jobs: raw_config.jobs,
             copy_jobs: raw_config.copy_jobs,
-            git_backend: match raw_config.git.backend {
-                Some(backend) => backend,
-                None => GitBackendType::try_default()?,
-            },
+            git_backend: raw_config.git.backend.unwrap_or_default(),
             git_executable: raw_config.git.executable_path,
         };
         trace!("Loaded configuration: {:?}", config);

--- a/src/git/backend/mod.rs
+++ b/src/git/backend/mod.rs
@@ -1,7 +1,6 @@
 pub mod error;
 pub mod types;
 
-#[cfg(feature = "git-backend-libgit2")]
 pub mod libgit2;
 
 #[cfg(feature = "git-backend-cli")]
@@ -70,9 +69,9 @@ impl std::fmt::Debug for WorktreeResult {
 }
 
 /// The type of git backend to use.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
 pub enum GitBackendType {
-    #[cfg(feature = "git-backend-libgit2")]
+    #[default]
     #[serde(rename = "libgit2")]
     Libgit2,
     #[cfg(feature = "git-backend-cli")]
@@ -80,25 +79,11 @@ pub enum GitBackendType {
     Cli,
 }
 
-impl GitBackendType {
-    #[allow(unreachable_code)]
-    pub fn try_default() -> anyhow::Result<Self> {
-        #[cfg(feature = "git-backend-libgit2")]
-        return Ok(GitBackendType::Libgit2);
-
-        #[cfg(feature = "git-backend-cli")]
-        return Ok(GitBackendType::Cli);
-
-        bail!("No git backend is enabled. Please enable at least one of `git-backend-libgit2` or `git-backend-cli` features.");
-    }
-}
-
 impl FromStr for GitBackendType {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            #[cfg(feature = "git-backend-libgit2")]
             "libgit2" => Ok(GitBackendType::Libgit2),
             #[cfg(feature = "git-backend-cli")]
             "cli" => Ok(GitBackendType::Cli),
@@ -113,7 +98,6 @@ pub fn create_backend(
     git_executable: Option<String>,
 ) -> Box<dyn GitBackend> {
     match backend_type {
-        #[cfg(feature = "git-backend-libgit2")]
         GitBackendType::Libgit2 => {
             info!("Using libgit2 git backend");
             Box::new(libgit2::Libgit2Backend::new())


### PR DESCRIPTION
Moving it behind a feature flag was a breaking change for those using `default-features = false`.
We probably still want to make it optional, but we will need a major version bump for that.