### PR TITLE
chore: drop unsupported x86_64-darwin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,24 +15,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1782918843,
@@ -52,23 +34,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     crane.url = "github:ipetkov/crane";
   };
 
@@ -11,17 +10,24 @@
     {
       self,
       nixpkgs,
-      flake-utils,
       crane,
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        inherit (pkgs) lib;
-        craneLib = crane.mkLib pkgs;
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
 
-        protofetch = craneLib.buildPackage {
+      mkProtofetch =
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          inherit (pkgs) lib;
+          craneLib = crane.mkLib pkgs;
+        in
+        craneLib.buildPackage {
           pname = "protofetch";
           src = lib.cleanSourceWith {
             src = ./.; # The original, unfiltered source
@@ -37,16 +43,21 @@
             export HOME=$(mktemp -d)
           '';
         };
-      in
-      {
-        packages = rec {
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          protofetch = mkProtofetch system;
+        in
+        rec {
           inherit protofetch;
           default = protofetch;
-        };
-        checks = {
-          # Build the crate as part of `nix flake check`
-          inherit protofetch;
-        };
-      }
-    );
+        }
+      );
+      checks = forAllSystems (system: {
+        # Build the crate as part of `nix flake check`
+        protofetch = self.packages.${system}.protofetch;
+      });
+    };
 }


### PR DESCRIPTION
Nixpkgs no longer supports x86_64-darwin, which was included in `flake-utils.lib.eachDefaultSystem`. This PR makes the supported systems list explicit, removes x86_64-darwin, and also removes the flake-utils dependency.